### PR TITLE
rosmake use -jN -lN (backported a6375042f362e0bbb46f8c99f939873ba928bd99...

### DIFF
--- a/tools/rosmake/src/rosmake/engine.py
+++ b/tools/rosmake/src/rosmake/engine.py
@@ -387,12 +387,13 @@ class RosMakeAll:
         """
         local_env = os.environ.copy()
         if self.ros_parallel_jobs > 0:
-            local_env['ROS_PARALLEL_JOBS'] = "-j -l%d" % self.ros_parallel_jobs
+            local_env['ROS_PARALLEL_JOBS'] = "-j%d -l%d" % (self.ros_parallel_jobs, self.ros_parallel_jobs)
         elif "ROS_PARALLEL_JOBS" not in os.environ: #if no environment setup and no args fall back to # cpus
             # num_cpus check can (on OS X) trigger a Popen(), which has
             #the multithreading bug we wish to avoid on Py2.7.
             with _popen_lock:
-                local_env['ROS_PARALLEL_JOBS'] = "-j -l%d" % parallel_build.num_cpus()
+                num_cpus = parallel_build.num_cpus()
+                local_env['ROS_PARALLEL_JOBS'] = "-j%d -l%d" % (num_cpus, num_cpus)
         local_env['SVN_CMDLINE'] = "svn --non-interactive"
         cmd = ["bash", "-c", "cd %s && %s "%(self.get_path(package), make_command()) ] #UNIXONLY
         if argument:


### PR DESCRIPTION
... and 4a4f6b9db302a4d19e2139e2688cddf1138240e9, #4)
