### PR TITLE
Path manipulation for windows

### DIFF
--- a/core/roslib/env-hooks/10.ros.bat.em
+++ b/core/roslib/env-hooks/10.ros.bat.em
@@ -1,7 +1,7 @@
 REM generated from ros/env-hooks/10.ros.bat.em
 
 REM scrub old ROS bin dirs, to avoid accidentally finding the wrong executables
-set COMMAND=python -c "import os; print(os.pathsep.join([x for x in r'%PATH%'.split(os.pathsep) if not any([d for d in ['cturtle', 'diamondback', 'electric', 'fuerte'] if d in x])]))"
+set _COMMAND=python -c "import os; print(os.pathsep.join([x for x in r'%PATH%'.split(os.pathsep) if not any([d for d in ['cturtle', 'diamondback', 'electric', 'fuerte'] if d in x])]))"
 rem Need the delims= line here to ensure that it reads with eol delimiters, not space.
 for /f "delims=" %%i in ('%COMMAND%') do set PATH=%%i
 
@@ -39,4 +39,4 @@ endlocal
 
 REM unset ROS workspace
 set ROS_WORKSPACE=
-set COMMAND=
+set _COMMAND=

--- a/core/roslib/env-hooks/10.ros.bat.em
+++ b/core/roslib/env-hooks/10.ros.bat.em
@@ -1,7 +1,9 @@
 REM generated from ros/env-hooks/10.ros.bat.em
 
 REM scrub old ROS bin dirs, to avoid accidentally finding the wrong executables
-set PATH=`python -c "import os; print(os.pathsep.join([x for x in \"$PATH\".split(os.pathsep) if not any([d for d in ['cturtle', 'diamondback', 'electric', 'fuerte'] if d in x])]))"`
+set COMMAND=python -c "import os; print(os.pathsep.join([x for x in r'%PATH%'.split(os.pathsep) if not any([d for d in ['cturtle', 'diamondback', 'electric', 'fuerte'] if d in x])]))"
+rem Need the delims= line here to ensure that it reads with eol delimiters, not space.
+for /f "delims=" %%i in ('%COMMAND%') do set PATH=%%i
 
 set ROS_DISTRO=groovy
 

--- a/core/roslib/env-hooks/10.ros.bat.em
+++ b/core/roslib/env-hooks/10.ros.bat.em
@@ -39,3 +39,4 @@ endlocal
 
 REM unset ROS workspace
 set ROS_WORKSPACE=
+set COMMAND=


### PR DESCRIPTION
The backtick command wasn't working on 64 bit machines due to the brackets in path directories such as `C:\Program Files (x86)\Microsoft ...`. It would drop out with the amusing error:

```
\Microsoft was unexpected at this time
```

This fixes that.
