### PR TITLE
make rosunit use print_function for python 2 and 3 compatibility (#11)

### DIFF
--- a/tools/rosunit/src/rosunit/core.py
+++ b/tools/rosunit/src/rosunit/core.py
@@ -29,8 +29,8 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-#
-# Revision $Id$
+
+from __future__ import print_function
 
 import os
 import sys
@@ -45,17 +45,17 @@ XML_OUTPUT_FLAG = '--gtest_output=xml:' #use gtest-compatible flag
 def printlog(msg, *args):
     if args:
         msg = msg%args
-    print "[ROSUNIT]"+msg
+    print("[ROSUNIT]"+msg)
     
 def printlog_bold(msg, *args):
     if args:
         msg = msg%args
-    print '\033[1m[ROSUNIT]%s\033[0m'%msg
+    print('\033[1m[ROSUNIT]' + msg + '\033[0m')
     
 def printerrlog(msg, *args):
     if args:
         msg = msg%args
-    print >> sys.stderr, "[ROSUNIT]"+msg
+    print("[ROSUNIT]"+msg, file=sys.stderr)
 
 # this is a copy of the roslogging utility. it's been moved here as it is a common
 # routine for programs using accessing ROS directories
@@ -154,7 +154,7 @@ def create_xml_runner(test_pkg, test_name, results_file=None, is_rostest=False):
     elif os.path.isfile(test_dir):
         raise Exception("ERROR: cannot run test suite, file is preventing creation of test dir: %s"%test_dir)
     
-    print "[ROSUNIT] Outputting test results to %s"%results_file
+    print("[ROSUNIT] Outputting test results to " + results_file)
     outstream = open(results_file, 'w')
     outstream.write('<?xml version="1.0" encoding="utf-8"?>\n')
     return XMLTestRunner(stream=outstream)

--- a/tools/rosunit/src/rosunit/pyunit.py
+++ b/tools/rosunit/src/rosunit/pyunit.py
@@ -35,7 +35,7 @@
 """
 Wrapper for running Python unittest within rosunit/rostest framework.
 """
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
 import sys
 
@@ -112,10 +112,10 @@ def start_coverage(packages):
             _cov.load()
             _cov.start()
         except coverage.CoverageException:
-            print >> sys.stderr, "WARNING: you have an older version of python-coverage that is not support. Please update to the version provided by 'easy_install coverage'"
+            print("WARNING: you have an older version of python-coverage that is not support. Please update to the version provided by 'easy_install coverage'", file=sys.stderr)
     except ImportError, e:
-        print >> sys.stderr, """WARNING: cannot import python-coverage, coverage tests will not run.
-To install coverage, run 'easy_install coverage'"""
+        print("""WARNING: cannot import python-coverage, coverage tests will not run.
+To install coverage, run 'easy_install coverage'""", file=sys.stderr)
 
 def stop_coverage(packages, html=None):
     """
@@ -158,16 +158,16 @@ def stop_coverage(packages, html=None):
                 _cov.report(m, show_missing=0)
                 for mod in m:
                     res = _cov.analysis(mod)
-                    print "\n%s:\nMissing lines: %s"%(res[0], res[3])
+                    print("\n%s:\nMissing lines: %s"%(res[0], res[3]))
                     
             if html:
                 
-                print "="*80+"\ngenerating html coverage report to %s\n"%html+"="*80
+                print("="*80+"\ngenerating html coverage report to %s\n"%html+"="*80)
                 _cov.html_report(all_mods, directory=html)
         except ImportError, e:
-            print >> sys.stderr, "WARNING: cannot import '%s', will not generate coverage report"%package
+            print("WARNING: cannot import '%s', will not generate coverage report"%package, file=sys.stderr)
     except ImportError, e:
-        print >> sys.stderr, """WARNING: cannot import python-coverage, coverage tests will not run.
-To install coverage, run 'easy_install coverage'"""
+        print("""WARNING: cannot import python-coverage, coverage tests will not run.
+To install coverage, run 'easy_install coverage'""", file=sys.stderr)
     
     

--- a/tools/rosunit/src/rosunit/rosunit_main.py
+++ b/tools/rosunit/src/rosunit/rosunit_main.py
@@ -32,7 +32,7 @@
 #
 # Revision $Id$
 
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
 import os
 import sys
@@ -87,7 +87,7 @@ def rosunitmain():
     if not pkg:
         pkg = rospkg.get_package_name(test_file)
     if not pkg:
-        print "Error: failed to determine package name for file '%s'; maybe you should supply the --package argument to rosunit?"%(test_file)
+        print("Error: failed to determine package name for file '%s'; maybe you should supply the --package argument to rosunit?"%(test_file))
         sys.exit(1)
 
     try:

--- a/tools/rosunit/src/rosunit/xmlrunner.py
+++ b/tools/rosunit/src/rosunit/xmlrunner.py
@@ -5,6 +5,8 @@ XML Test Runner for PyUnit
 # Written by Sebastian Rittau <srittau@jroger.in-berlin.de> and placed in
 # the Public Domain. With contributions by Paolo Borelli.
 
+from __future__ import print_function
+
 __revision__ = "$Id$"
 
 import os.path
@@ -357,7 +359,7 @@ class XMLTestRunnerTest(unittest.TestCase):
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
-                print "Test"
+                print("Test")
         self._try_test_run(TestTest, """<testsuite errors="0" failures="0" name="unittest.TestSuite" tests="1" time="0.000">
   <testcase classname="__main__.TestTest" name="test_foo" time="0.000"></testcase>
   <system-out><![CDATA[Test
@@ -373,7 +375,7 @@ class XMLTestRunnerTest(unittest.TestCase):
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
-                print >>sys.stderr, "Test"
+                print("Test", file=sys.stderr)
         self._try_test_run(TestTest, """<testsuite errors="0" failures="0" name="unittest.TestSuite" tests="1" time="0.000">
   <testcase classname="__main__.TestTest" name="test_foo" time="0.000"></testcase>
   <system-out><![CDATA[]]></system-out>


### PR DESCRIPTION
This is only a partial fix for issue #11, but it's a useful step in the right direction. 
