### PR TITLE
make eclipse-project issues

### DIFF
--- a/core/mk/cmake.mk
+++ b/core/mk/cmake.mk
@@ -46,6 +46,6 @@ eclipse-project:
 	awk -f $(shell rospack find mk)/eclipse.awk .project-cmake > .project
 	rm .project-cmake
 	python $(shell rospack find mk)/make_pydev_project.py
-
+	rm -r catkin catkin_generated CATKIN_IGNORE cmake_install.cmake devel gtest test_results
 
 include $(shell rospack find mk)/buildtest.mk

--- a/core/mk/eclipse.awk
+++ b/core/mk/eclipse.awk
@@ -5,6 +5,9 @@
                 printf "ROS_PACKAGE_PATH="ENVIRON["ROS_PACKAGE_PATH"]"|"
                 printf "PYTHONPATH="ENVIRON["PYTHONPATH"]"|"
                 printf "PATH="ENVIRON["PATH"]"|"
+                printf "LD_LIBRARY_PATH="ENVIRON["LD_LIBRARY_PATH"]"|"
+                printf "PKG_CONFIG_PATH="ENVIRON["PKG_CONFIG_PATH"]"|"
+                printf "CMAKE_PREFIX_PATH="ENVIRON["CMAKE_PREFIX_PATH"]"|"
                 print "</value>"
         } else {
                 print $0


### PR DESCRIPTION
In groovy the make eclipse-project target is broken, a first commit adds the inclusion of some missing environment variables that are needed to fix building from within eclipse, a second commit adds some cleanup of catkin generated files and directories.

Ruben
