### PR TITLE
Added shell functions for fish shell

### DIFF
--- a/tools/rosbash/rosfish
+++ b/tools/rosbash/rosfish
@@ -1,0 +1,278 @@
+function _rossed
+  if test (uname) = "Darwin" -o (uname) = "FreeBSD"
+      sed -E $argv
+  else
+      sed -r $argv
+  end
+end
+
+function _rosfind
+  if  test (uname) = "Darwin" -o (uanme) = "FreeBSD"
+    # BSD find needs -E for extended regexp
+    find -E $argv
+  else
+    find $argv
+  end
+end
+
+# _ros_location_find
+# based on $ROS_LOCATIONS, which the user can set to any colon
+# separated of key=folder pairs also resolves keys 'log' and
+# 'test_results' to ROS defaults finally resolves to package, then
+# stack echoes its result
+function _ros_location_find
+    set -l homedir (echo $HOME | sed -e "s/\//\t\//g" -e "s/\t/\\\/g")
+    set -l ROS_LOCATION_KEYS_ARR (echo $ROS_LOCATIONS | _rossed -e 's/([^:=]*)=([^:=]*)(:*[^=])*(:|$)/\1 /g')
+    set -l ROS_LOCATIONS_ARR (echo $ROS_LOCATIONS | _rossed -e 's/([^:=]*)=([^:=]*)(:*[^=])*(:|$)/\2 /g' -e "s/~/{$homedir}/g")
+    for key in $ROS_LOCATION_KEYS_ARR
+        if test $argv[1] = $key
+            echo $key
+            return 0
+        end
+    end
+
+    if test $argv[1] = log
+        echo (roslaunch-logs)
+        return 0
+    else if test $argv[1] = test_results
+        echo (rosrun rosunit test_results_dir.py)
+        return 0
+    end
+
+    set -l loc (set -x ROS_CACHE_TIMEOUT -1.0; rospack find $argv[1] 2> /dev/null)
+    if test $status != 0
+        set loc (set -x ROS_CACHE_TIMEOUT=-1.0; rosstack find $argv[1] 2> /dev/null)
+        if test $status != 0
+            return 1
+        end
+        echo $loc
+        return 0
+    end
+    echo $loc
+    return 0
+end
+
+function _ros_list_locations
+    set -l ROS_LOCATION_KEYS (echo $ROS_LOCATIONS | _rossed -e 's/([^:=]*)=([^:=]*)(:*[^=])*(:|$)/\1 /g')
+    set -l packages (set -x ROS_CACHE_TIMEOUT -1.0; rospack list-names)
+    set -l stacks (set -x ROS_CACHE_TIMEOUT -1.0; rosstack list-names)
+    echo $packages $stacks log test_results $ROS_LOCATION_KEYS | tr ' ' '\n'
+    return 0
+end
+
+function _ros_package_find
+    set -l loc (set -x ROS_CACHE_TIMEOUT -1.0; rospack find $1 2> /dev/null)
+    if test $status != 0
+        return 1
+    end
+    echo $loc
+    return 0
+end
+
+function _ros_list_packages
+    set -l packages (set -x ROS_CACHE_TIMEOUT -1.0; rospack list-names)
+    echo $packages | tr ' ' '\n'
+    return 0
+end
+
+function _ros_list_stacks
+    set -l stacks (set -x ROS_CACHE_TIMEOUT -1.0; rosstack list-names)
+    echo $stacks | tr ' ' '\n'
+    return 0
+end
+
+# takes as argument either just a package-path or just a pkgname
+# returns 0 for no argument or if package (+ path) exist, 1 else
+# on success with arguments returns [pkgname, abspath, relpath basename] 
+function _ros_decode_path
+    set -l rosname remainder
+    if test -z $argv[1]
+        return 0
+    end
+
+    set -l rosname (echo $argv[1] | sed -n 's/\([^/]\+\).*/\1/p')
+
+    if not test -z $rosname
+        set remainder (echo $argv[1] | sed -n "s/$rosname\(.*\)/\1/p")
+    else
+        set rosname $argv[1]
+        if test (count $argv) != "2" -o $argv[2] != "forceeval"
+           echo $rosname
+           return 1
+        end
+    end
+
+    set -l rosdir (_ros_location_find $rosname)
+    if test $status != "0"
+        echo $rosname
+        return 1
+    end
+
+    echo {$rosdir}{$remainder}
+    return 0
+end
+
+function rospython
+  if test -z $argv
+    python -i -c "import roslib; roslib.load_manifest('$1')"
+    return 0
+  end
+  if test (count $argv) = 1
+    if test $argv[1] = "--help"
+      echo -e "usage: rospython [package] \n\nRun python loading package manifest first."
+      return 0
+    end
+  end
+  if test -f ./manifest.xml
+    set pkgname (basename (pwd))
+    python -i -c "import roslib; roslib.load_manifest($pkgname)"
+  else
+    python
+  end
+end
+
+function roscd
+  if test -z $argv[1]
+    if test -n $ROS_WORKSPACE
+      cd $ROS_WORKSPACE
+      return 0
+    end
+    if test -n $CMAKE_PREFIX_PATH[1]
+      for ws in $CMAKE_PREFIX_PATH
+        ls $ws/.catkin
+        if test -f $ws/.catkin
+          cd $ws
+          return 0
+        end
+      end
+    end
+    echo -e "Neither ROS_WORKSPACE is set nor a catkin workspace is listed in CMAKE_PREFIX_PATH.  Please set ROS_WORKSPACE or source a catkin workspace to use roscd with no arguments."
+    return 1
+  end
+
+
+  if test $argv[1] = "--help"
+    echo -e "usage: roscd package\n\nJump to target package."
+    return 0
+  end
+
+  set -l rospath (_ros_decode_path $argv[1] forceeval)
+  if test -z $rospath
+    if test -z $ROS_WORKSPACE
+      echo -e "No ROS_WORKSPACE set.  Please set ROS_WORKSPACE to use roscd with no arguments."
+      return 1
+    end
+    cd $ROS_WORKSPACE
+    return 0
+  else
+    cd $rospath
+    return 0
+  end
+end
+
+function _is_integer
+  not test -z (expr $argv[1] - $argv[1] 2>/dev/null)
+  return $status
+end
+
+function rosd
+    if test (count $argv) != 0
+      if test $argv[1] = "--help"
+        echo -e "usage: rosd\n\nDisplays the list of currently remembered directories with indexes."
+        return 0
+      end
+    end
+    set count 0
+    for items in (dirs | sed -e 's/  /\n/g')
+        echo $count $items;
+        set count (expr $count + 1)
+    end
+end
+
+function rospd
+    if test (count $argv) != 0
+      if test $argv[1] = "--help"
+        echo -e "usage: rospd\n\nLike pushd, also accepts indexes from rosd."
+        return 0
+      end
+    else
+      echo -e "usage: rospd\n\nLike pushd, also accepts indexes from rosd."
+      return 0
+    end
+    set -l rospath (_ros_decode_path $argv[1] forceeval)
+    pushd $rospath > /dev/null
+    rosd
+end
+
+function rosls
+    if test (count $argv) != 0
+      if test $argv[1] = "--help"
+        echo -e "usage: rosls [package]\n\nLists contents of a package directory."
+        return 0
+      end
+    else
+      echo -e "usage: rosls [package]\n\nLists contents of a package directory."
+      return 0
+    end
+    set -l rospath (_ros_decode_path $argv[1] forceeval)
+    ls $rospath
+end
+
+# sets arg as return value
+function _roscmd
+    set -l opt
+    if test -n $CMAKE_PREFIX_PATH
+        set -l catkin_package_libexec_dir (catkin_find --without-underlays --libexec $argv[1] 2> /dev/null)
+    end
+    set -l pkgdir (_ros_package_find $argv[1])
+    if test -z $catkin_package_libexec_dir -a -z $pkgdir
+        echo "Couldn't find package $argv[1]"
+        return 1
+    end
+    set -l exepath (find -L $catkin_package_libexec_dir $pkgdir -name $2 -type f ! -regex .*/[.].* ! -regex .*$pkgdir\/build\/.* | uniq)
+    if test (count $execpath) = "0"
+        echo "That file does not exist in that package."
+        return 1
+    else if test (expr (count $exepath) '>' 1) = "1"
+        echo "You have chosen a non-unique filename, please pick one of the following:"
+        for i in (seq (count $execpath))
+            echo $i") " $execpath[i]
+        end
+        read choice
+        set -l opt $execpath[$choice]
+    else
+        set -l opt $exepath[1]
+    end
+    arg=$opt
+end
+
+function rosed
+    set -l arg
+    if test (count $argv) = 0
+       echo -e "usage: rossed [package] [file]\n\nEdit a file within a package."
+       return 0
+    end
+    if test $argv[1] = "--help"
+       echo -e "usage: rossed [package] [file]\n\nEdit a file within a package."
+       return 0
+    end
+    _roscmd $argv[1]
+    if test -n $arg
+        if test -z $EDITOR
+            vi $arg
+        else
+            $EDITOR $arg
+        end
+    end
+end
+
+function roscp
+    set -l arg
+    echo count is (count $argv)
+    if test  (count $argv) != "3"
+        echo -e "usage: roscp package filename target\n\nCopy a file from a package to target location."
+        return 0
+    end
+    _roscmd $argv[1] $argv[2]
+    cp $arg $argv[3]
+end


### PR DESCRIPTION
Hello, this is a commit to provide a version of the various shell functions found in ros bash to the fish shell.  Specifically, this is for the forked version under current development on github rather than the legacy version in the Debian/Ubuntu repositories.  I don't know anyone currently using that version.

I've duplicated all the functions, but none of the auto completions in this patch.  rospd works slightly differently but mirrors the way in which fish does pushing directories.

More info about fish:
https://en.wikipedia.org/wiki/Fish_shell
https://github.com/fish-shell/fish-shell
