### PR TITLE
Gendeps cache fix

### DIFF
--- a/core/roslib/scripts/gendeps
+++ b/core/roslib/scripts/gendeps
@@ -87,7 +87,7 @@ def gendeps_main(argv, stdout, stderr):
 
     # rospack instance for caching of deps
     rospack = rospkg.RosPack()
-    retval = roslib.gentools.get_file_dependencies(f, stdout=stdout, stderr=stderr)
+    retval = roslib.gentools.get_file_dependencies(f, stdout=stdout, stderr=stderr, rospack=rospack)
 
     if options.md5:
         print >> stdout, roslib.gentools.compute_md5(retval, rospack=rospack)

--- a/core/roslib/scripts/gendeps
+++ b/core/roslib/scripts/gendeps
@@ -44,6 +44,8 @@ import roslib.msgs
 import roslib.srvs
 import roslib.gentools
 
+import rospkg
+
 NAME='gendeps'
 
 def usage(progname, stdout=sys.stdout):
@@ -83,12 +85,14 @@ def gendeps_main(argv, stdout, stderr):
     if options.cat_files and (options.md5 or options.sha1):
         parser.error("cat option is not compatible with other options")
 
+    # rospack instance for caching of deps
+    rospack = rospkg.RosPack()
     retval = roslib.gentools.get_file_dependencies(f, stdout=stdout, stderr=stderr)
 
     if options.md5:
-        print >> stdout, roslib.gentools.compute_md5(retval)
+        print >> stdout, roslib.gentools.compute_md5(retval, rospack=rospack)
     elif options.sha1:
-        print >> stdout, roslib.gentools.compute_sha1(retval)
+        print >> stdout, roslib.gentools.compute_sha1(retval, rospack=rospack)
     elif options.cat_files:
         # this option is used for the message definition that is
         # stored in exchanged in ROS handshakes and then stored in bag

--- a/core/roslib/scripts/gendeps
+++ b/core/roslib/scripts/gendeps
@@ -40,10 +40,10 @@
 
 import sys
 
-import roslib.msgs 
-import roslib.srvs 
+import roslib.msgs
+import roslib.srvs
 import roslib.gentools
- 
+
 NAME='gendeps'
 
 def usage(progname, stdout=sys.stdout):
@@ -52,7 +52,7 @@ def usage(progname, stdout=sys.stdout):
 ## main method for gendeps command
 ## @param argv [str]: sys args
 ## @param stdout pipe: stdout pipe
-## @param stderr pipe: stderr pipe                
+## @param stderr pipe: stderr pipe
 def gendeps_main(argv, stdout, stderr):
     from optparse import OptionParser
     parser = OptionParser(usage="usage: %prog [options] [files...]", prog=NAME)
@@ -88,7 +88,7 @@ def gendeps_main(argv, stdout, stderr):
     if options.md5:
         print >> stdout, roslib.gentools.compute_md5(retval)
     elif options.sha1:
-        print >> stdout, roslib.gentools.compute_sha1(retval)        
+        print >> stdout, roslib.gentools.compute_sha1(retval)
     elif options.cat_files:
         # this option is used for the message definition that is
         # stored in exchanged in ROS handshakes and then stored in bag

--- a/core/roslib/src/roslib/gentools.py
+++ b/core/roslib/src/roslib/gentools.py
@@ -250,7 +250,7 @@ def compute_full_text(get_deps_dict):
     # #1168: remove the trailing \n separator that is added by the concatenation logic
     return buff.getvalue()[:-1]
 
-def get_file_dependencies(f, stdout=sys.stdout, stderr=sys.stderr):
+def get_file_dependencies(f, stdout=sys.stdout, stderr=sys.stderr, rospack=None):
     """
     Compute dependencies of the specified message/service file
     @param f: message or service file to get dependencies for
@@ -272,7 +272,7 @@ def get_file_dependencies(f, stdout=sys.stdout, stderr=sys.stderr):
         _, spec = roslib.srvs.load_from_file(f)
     else:
         raise Exception("[%s] does not appear to be a message or service"%spec)
-    return get_dependencies(spec, package, stdout, stderr)
+    return get_dependencies(spec, package, stdout, stderr, rospack=rospack)
 
 def get_dependencies(spec, package, compute_files=True, stdout=sys.stdout, stderr=sys.stderr, rospack=None):
     """

--- a/core/roslib/src/roslib/gentools.py
+++ b/core/roslib/src/roslib/gentools.py
@@ -52,10 +52,10 @@ except ImportError:
 
 import rospkg
 
-import roslib.msgs 
+import roslib.msgs
 from roslib.msgs import MsgSpecException
-import roslib.names 
-import roslib.srvs 
+import roslib.names
+import roslib.srvs
 
 # name of the Header type as gentools knows it
 _header_type_name = 'std_msgs/Header'
@@ -78,12 +78,12 @@ def _add_msgs_depends(rospack, spec, deps, package_context):
         # package is not present.  we soft fail here because we assume
         # missing messages will be caught later during lookup.
         pass
-    
+
     for t in spec.types:
         t = roslib.msgs.base_msg_type(t)
         if not roslib.msgs.is_builtin(t):
             t_package, t_base = roslib.names.package_resource_name(t)
-            
+
             # special mapping for header
             if t == roslib.msgs.HEADER:
                 # have to re-names Header
@@ -124,7 +124,7 @@ def compute_md5_text(get_deps_dict, spec, rospack=None):
     # #1554: need to suppress computation of files in dynamic generation case
     compute_files = 'files' in get_deps_dict
 
-    buff = StringIO()    
+    buff = StringIO()
 
     for c in spec.constants:
         buff.write("%s %s=%s\n"%(c.type, c.name, c.val_text))
@@ -141,14 +141,14 @@ def compute_md5_text(get_deps_dict, spec, rospack=None):
             # - ugly special-case handling of Header
             if base_msg_type == roslib.msgs.HEADER:
                 base_msg_type = _header_type_name
-                
+
             sub_pkg, _ = roslib.names.package_resource_name(base_msg_type)
             sub_pkg = sub_pkg or package
             sub_spec = roslib.msgs.get_registered(base_msg_type, package)
             sub_deps = get_dependencies(sub_spec, sub_pkg, compute_files=compute_files, rospack=rospack)
             sub_md5 = compute_md5(sub_deps, rospack)
             buff.write("%s %s\n"%(sub_md5, name))
-    
+
     return buff.getvalue().strip() # remove trailing new line
 
 def _compute_hash(get_deps_dict, hash, rospack=None):
@@ -156,8 +156,8 @@ def _compute_hash(get_deps_dict, hash, rospack=None):
     subroutine of compute_md5()
     @param get_deps_dict: dictionary returned by get_dependencies call
     @type  get_deps_dict: dict
-    @param hash: hash instance            
-    @type  hash: hash instance            
+    @param hash: hash instance
+    @type  hash: hash instance
     """
     # accumulate the hash
     # - root file
@@ -170,7 +170,7 @@ def _compute_hash(get_deps_dict, hash, rospack=None):
         hash.update(compute_md5_text(get_deps_dict, spec.request, rospack=rospack))
         hash.update(compute_md5_text(get_deps_dict, spec.response, rospack=rospack))
     else:
-        raise Exception("[%s] is not a message or service"%spec)   
+        raise Exception("[%s] is not a message or service"%spec)
     return hash.hexdigest()
 
 def _compute_hash_v1(get_deps_dict, hash):
@@ -179,10 +179,10 @@ def _compute_hash_v1(get_deps_dict, hash):
     @param get_deps_dict: dictionary returned by get_dependencies call
     @type  get_deps_dict: dict
     @param hash: hash instance
-    @type  hash: hash instance    
+    @type  hash: hash instance
     """
     uniquedeps = get_deps_dict['uniquedeps']
-    spec = get_deps_dict['spec']    
+    spec = get_deps_dict['spec']
     # accumulate the hash
     # - root file
     hash.update(spec.text)
@@ -240,7 +240,7 @@ def compute_full_text(get_deps_dict):
 
     # write the text of the top-level type
     buff.write(get_deps_dict['spec'].text)
-    buff.write('\n')    
+    buff.write('\n')
     # append the text of the dependencies (embedded types)
     for d in get_deps_dict['uniquedeps']:
         buff.write(sep)
@@ -288,18 +288,18 @@ def get_dependencies(spec, package, compute_files=True, stdout=sys.stdout, stder
     @param compute_files: (optional, default=True) compute file
     dependencies of message ('files' key in return value)
     @type  compute_files: bool
-    @return: dict: 
+    @return: dict:
       * 'files': list of files that \a file depends on
       * 'deps': list of dependencies by type
-      * 'spec': Msgs/Srvs instance. 
+      * 'spec': Msgs/Srvs instance.
       * 'uniquedeps': list of dependencies with duplicates removed,
       * 'package': package that dependencies were generated relative to.
-    @rtype: dict    
+    @rtype: dict
     """
 
     # #518: as a performance optimization, we're going to manually control the loading
     # of msgs instead of doing package-wide loads.
-    
+
     #we're going to manipulate internal apis of msgs, so have to
     #manually init
     roslib.msgs._init()
@@ -312,19 +312,19 @@ def get_dependencies(spec, package, compute_files=True, stdout=sys.stdout, stder
             _add_msgs_depends(rospack, spec, deps, package)
         elif isinstance(spec, roslib.srvs.SrvSpec):
             _add_msgs_depends(rospack, spec.request, deps, package)
-            _add_msgs_depends(rospack, spec.response, deps, package)                
+            _add_msgs_depends(rospack, spec.response, deps, package)
         else:
             raise MsgSpecException("spec does not appear to be a message or service")
     except KeyError, e:
         raise MsgSpecException("Cannot load type %s.  Perhaps the package is missing a dependency."%(str(e)))
 
     # convert from type names to file names
-    
+
     if compute_files:
         files = {}
         for d in set(deps):
             d_pkg, t = roslib.names.package_resource_name(d)
-            d_pkg = d_pkg or package # convert '' -> local package 
+            d_pkg = d_pkg or package # convert '' -> local package
             files[d] = roslib.msgs.msg_file(d_pkg, t)
     else:
         files = None
@@ -338,7 +338,7 @@ def get_dependencies(spec, package, compute_files=True, stdout=sys.stdout, stder
     if compute_files:
         return { 'files': files, 'deps': deps, 'spec': spec, 'package': package, 'uniquedeps': uniquedeps }
     else:
-        return { 'deps': deps, 'spec': spec, 'package': package, 'uniquedeps': uniquedeps }        
+        return { 'deps': deps, 'spec': spec, 'package': package, 'uniquedeps': uniquedeps }
 
 
 


### PR DESCRIPTION
This bug request follows a report of slow performanceof gendeps from Anthony Mallet at LAAS, for building ROS packages over NFS.

It seems to me the gendeps script is not using the rospack instance caching as intended by rospack and gentools.py.

To make sure this improves performance, I intentionally made my ROS_PACKAGE_PATH include large non-ROS subtrees to simulate lenghty file IO, such as 

```
 export ROS_PACKAGE_PATH:$ROS_PACKAGE_PATH:/home/kruset
```

Then for testing, I used this call in a groovy underlay from source:

```
$ time install/lib/roslib/gendeps --md5 src/nav_msgs/msg/OccupancyGrid.msg 
3381f2d731d4076ec5c71b0759edbe4e
real    0m10.908s
user    0m6.404s
sys     0m4.400s
```

(after calling several times to initialize rospack cache)
After applying the path, i get results such as this:

```
real    0m2.960s
user    0m1.888s
sys     0m1.032s
```

MD5 calculationthen is still slow, will investigate further.

If possible, please apply to fuerte, groovy and hydro sources (even if fuerte won't be released with patch).

Note that with all the duplicate code of md5 calculation between roslib and genpy/genmsg, I cannot tell whether the latter suffers the same performance hits. If this PR is considered valid, I recommend checking in genpy/genmsg as well.
