### PR TITLE
lazy initialize valid package names

### DIFF
--- a/core/roslib/src/roslib/gentools.py
+++ b/core/roslib/src/roslib/gentools.py
@@ -70,14 +70,18 @@ def _add_msgs_depends(rospack, spec, deps, package_context):
     @type  deps: [str]
     @raise KeyError for invalid dependent types due to missing package dependencies.
     """
-    valid_packages = ['', package_context]
-    try:
-        valid_packages = valid_packages + rospack.get_depends(package_context, implicit=True)
-    except rospkg.ResourceNotFound:
-        # this happens in dynamic generation situations where the
-        # package is not present.  we soft fail here because we assume
-        # missing messages will be caught later during lookup.
-        pass
+    def _get_valid_packages(package_context, rospack):
+        valid_packages = ['', package_context]
+        try:
+            valid_packages = valid_packages + rospack.get_depends(package_context, implicit=True)
+        except rospkg.ResourceNotFound:
+            # this happens in dynamic generation situations where the
+            # package is not present.  we soft fail here because we assume
+            # missing messages will be caught later during lookup.
+            pass
+        return valid_packages
+
+    valid_packages = None
 
     for t in spec.types:
         t = roslib.msgs.base_msg_type(t)
@@ -96,16 +100,18 @@ def _add_msgs_depends(rospack, spec, deps, package_context):
                         deps.append(t)
                     else:
                         deps.append(package_context+'/'+t)
-
-            elif t_package in valid_packages:
-                # if we are allowed to load the message, load it.
-                key, depspec = roslib.msgs.load_by_type(t, package_context)
-                if t != roslib.msgs.HEADER:
-                  deps.append(key)
-                roslib.msgs.register(key, depspec)
             else:
-                # not allowed to load the message, so error.
-                raise KeyError(t)
+                if valid_packages is None:
+                    valid_packages = _get_valid_packages(package_context, rospack)
+                if t_package in valid_packages:
+                    # if we are allowed to load the message, load it.
+                    key, depspec = roslib.msgs.load_by_type(t, package_context)
+                    if t != roslib.msgs.HEADER:
+                      deps.append(key)
+                    roslib.msgs.register(key, depspec)
+                else:
+                    # not allowed to load the message, so error.
+                    raise KeyError(t)
             _add_msgs_depends(rospack, depspec, deps, package_context)
 
 def compute_md5_text(get_deps_dict, spec, rospack=None):


### PR DESCRIPTION
This can save rospack roscache update call, when only primitive types are used (E.g. Pose2D below uses 3 floats).

Again, with a ROS_PACKAGE_PATH that includes a lot of useless stuff, I tried without and with the patch:

Before:

```
$ time install/lib/roslib/gendeps src/geometry_msgs/msg/Pose2D.msg 
real    0m3.348s
user    0m2.172s
sys     0m1.160s
```

After:

```
$ time install/lib/roslib/gendeps --md5 src/geometry_msgs/msg/Pose2D.msg 
938fa65709584ad8e77d238529be13b8
real    0m1.119s
user    0m0.728s
sys     0m0.388s
```

I think the patch also makes sense by just reading it. The variable valid_packages is initialized even when not used, and initialization involves rospack cache update.
