### PR TITLE
Show error message and return code when invalid path passed to rospd.

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -210,9 +210,14 @@ function rospd {
     else
         local rosvals
         _ros_decode_path $1 forceeval
+        if [ $? != 0 ]; then
+            echo "rospd: No such package/stack '$1'"
+            return 1
+        fi
         pushd ${rosvals[1]}${rosvals[2]}${rosvals[3]} > /dev/null ;
     fi
     rosd
+    return 0
 }
 
 function rosls {


### PR DESCRIPTION
Increases the scriptability of rospd to have it return 1 (like roscd) when the package can't be found.
