### PR TITLE
Allow python file to pass 'executable filter' in Windows

### DIFF
--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -401,7 +401,10 @@ def find_node(pkg, node_type, rospack=None):
 
 def _executable_filter(test_path):
     s = os.stat(test_path)
-    return (s.st_mode & (stat.S_IRUSR | stat.S_IXUSR) == (stat.S_IRUSR | stat.S_IXUSR))
+    flags = stat.S_IRUSR | stat.S_IXUSR
+    if os.name == 'nt' and os.path.splitext(test_path)[1] == '.py':
+        flags = stat.S_IRUSR
+    return (s.st_mode & flags) == flags
 
 def _find_resource(d, resource_name, filter_fn=None):
     """


### PR DESCRIPTION
The ros in windows can't create node process if the node is python file(.py) because the filter to test blocks. The os.stat returns the attributes except 'executable' for python file in windows.

To resolve it, `_executable_fileter()` allows python file to pass the filter in Windows.
