### PR TITLE
Add --prefix option to rosrun

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -419,29 +419,45 @@ function _roscomplete_rossrv {
     fi
 }
 
+function _roscomplete_pkg {
+    local arg=${1}
+    local opts=`_ros_list_packages`
+    IFS=$'\n'
+    COMPREPLY=($(compgen -W "${opts}" -- ${arg}))
+    unset IFS
+}
+
+function _roscomplete_find {
+    local opts pkgdir catkin_package_libexec_dir
+    local perm=${1}
+    local pkg=${2}
+    local arg=${3}
+    if [[ -n $CMAKE_PREFIX_PATH ]]; then
+        catkin_package_libexec_dir=`catkin_find --without-underlays --libexec ${pkg} 2> /dev/null`
+    fi
+    pkgdir=`_ros_package_find ${pkg}`
+    if [[ -n "$catkin_package_libexec_dir" || -n "$pkgdir" ]]; then
+        opts=`_rosfind -L $catkin_package_libexec_dir $pkgdir ${1} ! -regex ".*/[.].*" ! -regex ".*$pkgdir\/build\/.*"  -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g"`
+    else
+        opts=""
+    fi
+    IFS=$'\n'
+    COMPREPLY=($(compgen -W "${opts}" -- ${arg}))
+    unset IFS
+}
+
 function _roscomplete_search_dir {
-    local arg opts pkgdir catkin_package_libexec_dir
+    local arg opts
     COMPREPLY=()
     arg="${COMP_WORDS[COMP_CWORD]}"
     if [[ $COMP_CWORD == 1 ]]; then
-        opts=`_ros_list_packages`
-        IFS=$'\n'
-        COMPREPLY=($(compgen -W "${opts}" -- ${arg}))
-        unset IFS
+        # complete packages
+        _roscomplete_pkg "${arg}"
     elif [[ $COMP_CWORD == 2 ]]; then
-        if [[ -n $CMAKE_PREFIX_PATH ]]; then
-            catkin_package_libexec_dir=`catkin_find --without-underlays --libexec ${COMP_WORDS[1]} 2> /dev/null`
-        fi
-        pkgdir=`_ros_package_find ${COMP_WORDS[1]}`
-        if [[ -n "$catkin_package_libexec_dir" || -n "$pkgdir" ]]; then
-            opts=`_rosfind -L $catkin_package_libexec_dir $pkgdir ${1} ! -regex ".*/[.].*" ! -regex ".*$pkgdir\/build\/.*"  -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g"`
-        else
-            opts=""
-        fi
-        IFS=$'\n'
-        COMPREPLY=($(compgen -W "${opts}" -- ${arg}))
-        unset IFS
+        # complete files within package according to $1
+        _roscomplete_find "${1}" "${COMP_WORDS[1]}" "${arg}"
     else
+       # complete filenames
        arg=`echo ${arg} | sed -e "s|~|$HOME|g"`
         if [[ $arg =~ ^/*.+/.* ]]; then
            path=${arg%/*}

--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -420,6 +420,7 @@ function _roscomplete_rossrv {
 }
 
 function _roscomplete_pkg {
+    # complete package names that start with $1
     local arg=${1}
     local opts=`_ros_list_packages`
     IFS=$'\n'
@@ -428,6 +429,7 @@ function _roscomplete_pkg {
 }
 
 function _roscomplete_find {
+    # complete files that match $2 within $1, that start with $3
     local opts pkgdir catkin_package_libexec_dir
     local perm=${1}
     local pkg=${2}
@@ -486,13 +488,65 @@ function _roscomplete_search_dir {
 }
 
 function _roscomplete_exe {
-    local perm
+    local perm i prev_arg
     if [[ `uname` == Darwin ]]; then
         perm="+111"
     else
         perm="/111"
     fi
-    _roscomplete_search_dir "-type f -perm $perm"
+    rosrun_args=("--prefix" "--debug")
+
+    # rosrun ONLY accepts arguments before the package names; we need to honor this
+    local start_arg=1
+    # loop through args and skip --prefix, arg to prefix and --debug
+    for (( i=1; i < ${#COMP_WORDS[*]}; i++ ))
+    do
+        arg="${COMP_WORDS[i]}"
+        case ${arg} in
+            "--prefix" | "-p")
+              start_arg=$((start_arg+1))
+              ;;
+            "--debug" | "-d")
+              start_arg=$((start_arg+1))
+              ;;
+            *)
+              if [[ $prev_arg == "--prefix" || $prev_arg == "-p" ]]
+              then
+                  start_arg=$((start_arg+1))
+              else
+                  break
+              fi
+              ;;
+        esac
+        prev_arg="${arg}"
+    done
+
+    local end_arg=$((${#COMP_WORDS[*]} - 1))
+    arg="${COMP_WORDS[COMP_CWORD]}"
+
+    if [[ $start_arg > $end_arg ]]
+    then
+        # complete command names for --prefix
+        COMPREPLY=($(compgen -c -- ${arg}))
+    else
+        if [[ $start_arg == $end_arg ]]
+        then
+            # completing first argument; can be --arg or package name
+            if [[ ${arg} =~ \-.* ]]; then
+                COMPREPLY=($(compgen -W "${rosrun_args[*]}" -- ${arg}))
+            else
+                _roscomplete_pkg "${arg}"
+            fi
+        elif [[ $((start_arg+1)) == ${end_arg} ]]
+        then
+            # completing second argument; node within package
+            local pkg="${COMP_WORDS[start_arg]}"
+            _roscomplete_find "-type f -perm $perm" "${pkg}" "${arg}"
+        else
+            # completing remaining arguments; per "normal"
+            _roscomplete_search_dir "-type f -perm $perm"
+        fi
+    fi
 }
 
 function _roscomplete_file {

--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -302,15 +302,26 @@ function _roscomplete_sub_dir {
 }
 
 function _roscomplete_search_dir {
-    local words arg opts pkgdir pkgdir_result stack_result
+    local words arg opts pkg pkgdir pkgdir_result stack_result catkin_package_libexec_dir
     reply=()
 		words=(${=BUFFER})
-    pkgdir=`export ROS_CACHE_TIMEOUT=-1.0 && rospack find ${words[2]} 2> /dev/null`
+    if [[ $BUFFER[-1] == ' ' ]]
+    then
+        pkg=${words[-1]}
+    else
+        pkg=${words[-2]}
+    fi
+    pkgdir=`export ROS_CACHE_TIMEOUT=-1.0 && rospack find ${pkg} 2> /dev/null`
     pkgdir_result=$?
-    stackdir=`export ROS_CACHE_TIMEOUT=-1.0 && rosstack find ${words[2]} 2> /dev/null`
+    catkin_package_libexec_dir=`catkin_find --without-underlays --libexec ${pkg} 2> /dev/null`
+    if [[ $? != 0 ]]
+    then
+        catkin_package_libexec_dir=""
+    fi
+    stackdir=`export ROS_CACHE_TIMEOUT=-1.0 && rosstack find ${pkg} 2> /dev/null`
     stack_result=$?
     if [[ $pkgdir_result == 0 ]]; then
-        opts=`find $pkgdir ${=1} -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g"`
+        opts=`find $pkgdir $catkin_package_libexec_dir ${=1} -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g"`
     elif [[ $stack_result == 0 ]] ; then
         opts=`find $stackdir ${=1} -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g"`
     else
@@ -701,7 +712,7 @@ compctl -K "_roscomplete_rosmake" "rosmake"
 
 compctl -x 'p[1]' -k "(check purge)" -- "rosclean"
 compctl -f -x 'p[1]' -K "_roscomplete" - 'p[2]' -K _roscomplete_file -- "rosed" "roscp"
-compctl -f -x 'p[1]' -K "_roscomplete" - 'p[2]' -K _roscomplete_exe -- "rosrun"
+compctl -f -x 'S[-]' -k '(--debug --prefix)' - 'c[-1,--prefix][-1,-p]' -h '' - 'p[1],c[-1,-d],c[-1,--debug],c[-2,-p],c[-2,--prefix]' -K "_roscomplete" - 'p[2],c[-2,-d],c[-2,--debug],c[-3,-p],c[-3,--prefix]' -K _roscomplete_exe -- "rosrun"
 compctl -/g '*.(launch|test)' -x 'p[1]' -K "_roscomplete" -tx - 'p[2]' -K _roscomplete_launchfile -- + -x 'S[--]' -k "(--files --args --nodes --find-node --child --local --screen --server_uri --run_id --wait --port --core --pid --dump-params)" -- "roslaunch"
 compctl -/g '*.(launch|test)' -x 'p[1]' -K "_roscomplete" -tx - 'p[2]' -K _roscomplete_launchfile -- + -x 'S[--]' -k "(--bare --bare-limit --bare-name --pkgdir --package)" -- "rostest"
 compctl -K "_roscomplete_rospack" "rospack"

--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -1,30 +1,58 @@
 #!/usr/bin/env bash
-if [[ $1 = "--help" ]]; then
-  echo "Usage: rosrun PACKAGE EXECUTABLE [ARGS]"
+
+function usage() {
+  echo "Usage: rosrun [--prefix cmd] [--debug] PACKAGE EXECUTABLE [ARGS]"
   echo "  rosrun will locate PACKAGE and try to find"
   echo "  an executable named EXECUTABLE in the PACKAGE tree."
   echo "  If it finds it, it will run it with ARGS."
+}
+
+args=1
+rosrun_prefix=""
+
+function debug() {
+  return
+}
+
+while [ $args == 1 ]
+do
+  case $1 in
+    "--help" | "-h")
+      usage
+      exit 0
+      ;;
+    "--prefix" | "-p")
+      rosrun_prefix=$2
+      shift
+      shift
+      ;;
+    "--debug" | "-d")
+      shift
+      function debug() { echo "[rosrun]" "$@" ; }
+      ;;
+    *) # default
+      args=0
+  esac
+done
+
+if [ $# -lt 2 ]; then
+  usage
   exit 0
 fi
-if [ $# -lt 2 ]; then
-  echo "Usage: rosrun PACKAGE EXECUTABLE [ARGS]"
-  echo "  rosrun will locate PACKAGE and try to find"
-  echo "  an executable named EXECUTABLE in the PACKAGE tree."
-  echo "  If it finds it, it will run it with ARGS."
-  exit 1
-fi
+
 # early check that filename does not end with '/'
 case $2 in
   */) echo "Invalid filename: " $2
     exit 1
     ;;
 esac
-# basename also makes .//foo into foo
-basename=`basename $2`
+
 if [[ -n $CMAKE_PREFIX_PATH ]]; then
   catkin_package_libexec_dir=`catkin_find --without-underlays --libexec --share $1 2> /dev/null`
+  debug "Looking in catkin libexec dir: $catkin_package_libexec_dir"
 fi
 pkgdir=`rospack find $1`
+debug "Looking in rospack dir: $pkgdir"
 if [[ -z $catkin_package_libexec_dir && -z $pkgdir ]]; then
   exit 2
 fi
@@ -37,6 +65,7 @@ if [[ ! $2 == */* ]]; then
   else
     _perm="/111"
   fi
+  debug "Searching for $2 with permissions $_perm"
   exepathlist=(`find -L $catkin_package_libexec_dir $pkgdir -name $2 -type f  -perm $_perm ! -regex ".*$pkgdir\/build\/.*" | uniq`)
   unset _perm
   if [[ ${#exepathlist[@]} == 0 ]]; then
@@ -62,6 +91,7 @@ if [[ ! $2 == */* ]]; then
   fi
 else
   absname=$pkgdir/$2
+  debug "Path given. Looing for $absname"
   if [ ! -f $absname -o ! -x $absname ]; then
     echo "[rosrun] Couldn't find executable named $absname"
     exit 3
@@ -70,4 +100,5 @@ else
 fi
 shift
 shift
-exec $exepath "$@"
+debug "Running $rosrun_prefix $exepath" "$@"
+exec $rosrun_prefix $exepath "$@"


### PR DESCRIPTION
With catkin, binaries have moved from the bin/ folder within the package into the devel/build folders in the catkin workspace; this makes it difficult to find them without understanding the workspace layout.

I've also seen a number of comments indicating that "gdb doesn't work with rosrun"

I think the solution to these is that rosrun should have a `--prefix` option to allow users to run their programs within gdb, valgrind and other debug tools.
