### PR TITLE
Remove unnecessary -lrt for Android

### DIFF
--- a/core/roslib/CMakeLists.txt
+++ b/core/roslib/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 add_library(roslib src/package.cpp)
 target_link_libraries(roslib ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
-if(NOT (APPLE OR WIN32 OR MINGW))
+if(NOT (APPLE OR WIN32 OR MINGW OR ANDROID))
   target_link_libraries(roslib rt)
 endif()
 


### PR DESCRIPTION
This enables the use of roslib with an android cross toolchain that defines ANDROID.

Similar to https://github.com/ros/catkin/pull/430
