### PR TITLE
Explicit disabling of batch file delayed expansion

### DIFF
--- a/core/roslib/env-hooks/10.ros.bat.em
+++ b/core/roslib/env-hooks/10.ros.bat.em
@@ -9,6 +9,7 @@ set ROS_DISTRO=hydro
 
 REM python function to generate ROS package path based on all parent workspaces (prepends the separator if necessary)
 REM do not use EnableDelayedExpansion here, it messes with the != symbols
+setlocal disabledelayedexpansion
 echo from __future__ import print_function > _parent_package_path.py
 echo import os >> _parent_package_path.py
 echo env_name = 'CATKIN_WORKSPACES' >> _parent_package_path.py
@@ -17,6 +18,7 @@ echo path = '' >> _parent_package_path.py
 echo for item in items: >> _parent_package_path.py
 echo     path += ':' + (os.path.join(item, 'share') if item.find(':') == -1 else item.split(':')[1]) >> _parent_package_path.py
 echo print(path) >> _parent_package_path.py
+endlocal
 
 setlocal EnableDelayedExpansion
 


### PR DESCRIPTION
Windows environment hooks are a nesting of batch files. Changes in the way catkin sets up environment hooks will likely require the use of delayed expansion in upper level batch scripts that call this script. Delayed expansion settings are inherited through the chain of execution when batch files call each other.

Although it was commented that delayed expansion should be disabled for the period of echo'ing python code, this patch explicitly disables delayed expansion for that portion of the file.

See this pull request in win_ros for further context: [win_ros pull request #44](https://github.com/ros-windows/win_ros/pull/44)
