### PR TITLE
"std_msgs/Header header" is not considered to be a header  in messages generated with rosbuild

### DIFF
--- a/core/roslib/src/roslib/msgs.py
+++ b/core/roslib/src/roslib/msgs.py
@@ -301,7 +301,7 @@ class MsgSpec(object):
         assert len(self.types) == len(self.names), "len(%s) != len(%s)"%(self.types, self.names)
         #Header.msg support
         if (len(self.types)):
-            self.header_present = self.types[0] == HEADER and self.names[0] == 'header'
+            self.header_present = is_header_type(self.types[0]) and self.names[0] == 'header'
         else:
             self.header_present = False
         self.text = text


### PR DESCRIPTION
Follow up of ros/gencpp#21.

The message parser used for `rosbuild` only considers the field `Header header` to be a header.

`std_msgs/Header header` is not accepted which leads to not generating certain message traits: https://github.com/ros/ros/blob/01f9fc1140e2940be2799688aca85d5441807fa7/core/roslib/src/roslib/msgs.py#L304
