### PR TITLE
rosbash: Fix zsh rosservice completion.

### DIFF
--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -565,7 +565,7 @@ function _roscomplete_rosservice {
         opts="list call type find uri"
         reply=(${=opts})
     elif [[ ${CURRENT} == 3 ]]; then
-        case ${=${(s: :)words}[2]} in
+        case ${words[2]} in
             uri|list|type|call)
                 opts=`rosservice list 2> /dev/null`
                 IFS=$'\n'
@@ -573,16 +573,15 @@ function _roscomplete_rosservice {
                 unset IFS
                 ;;
             find)
-                opts=`_srv_opts ${=${(s: :)words[-1]}}`
+                opts=`_srv_opts ${words[3]}`
                 reply=(${=opts})
                 ;;
         esac
     elif [[ ${CURRENT} == 4 ]]; then
-        case ${=${(s: :)words}[2]} in
+        case ${words[2]} in
             call)
-                type=`rosservice type ${=${(s: :)words[-1]}}`
-                opts=`rosmsg-proto srv 2> /dev/null -s ${type}`
-                reply=(${=opts})
+                type="$(rosservice type ${words[3]} 2>/dev/null)"
+                reply=("$(rosmsg-proto srv -s ${type} 2> /dev/null)")
                 ;;
         esac
     fi
@@ -740,7 +739,7 @@ compctl -K "_roscomplete_rosbag" + -g "*.bag *(/)" "rosbag"
 compctl -K "_roscomplete_rosnode" "rosnode"
 compctl -K "_roscomplete_rosparam" "rosparam"
 compctl -x 'p[0,2]' -K "_roscomplete_rostopic" - 'n[1,/] p[3]' -K "_roscomplete_rostopic" - 'p[3]' -S ' ' -K "_roscomplete_rostopic" - 'p[4]' -Q -K "_roscomplete_rostopic" -- "rostopic"
-compctl -K "_roscomplete_rosservice" "rosservice"
+compctl -Q -K "_roscomplete_rosservice" "rosservice"
 compctl -x 'p[1]' -k "(md5 package packages show users)" - 'p[2]' -S '' -K "_roscomplete_rosmsg" -- "rosmsg"
 compctl -x 'p[1]' -k "(md5 package packages show users)" - 'p[2]' -S '' -K "_roscomplete_rossrv" -- "rossrv"
 compctl -K "_roscomplete_roscreate_pkg" "roscreate-pkg"


### PR DESCRIPTION
I had to change this for rosservice completion to work correctly. `${words[-1]}` is the message value (possibly empty string) at this point and not the service name. I changed it to `${words[3]}`. `${words[-2]}` should also work, but since the subcommand is already hardcoded as `${words[2]}` and there are no optional options I saw no harm in hardcoding index 3 as well.

Also I am very curious why the words array is being accessed sometimes as `${=${(s: :)words[x]}}`. It seems like a very elaborate NOP to me. Why do that over `${words[x]}`?

Alternatively `${=${(s: :)words}[x]}` is not a NOP (though the second split might be) but seems plain wrong to me. We should not be doing word splitting at all, the shell has already done that while taking into account quotes and escape characters and what not. Flattening the array into a string and then splitting on spaces is simply wrong, not to mention more complex and hard to read.

/edit:

The complection that was not working was:
`rosservice call /some/service [tab]`

It should give the layout of the request body so you can fill in details. However, it just wrote errors to stderr. After the PR it should fill in the request body.
