### PR TITLE
rosrun: Allow spaces in command names and search paths.

### DIFF
--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -16,13 +16,13 @@ function debug() {
 
 while [ $args == 1 ]
 do
-  case $1 in
+  case "$1" in
     "--help" | "-h")
       usage
       exit 0
       ;;
     "--prefix" | "-p")
-      rosrun_prefix=$2
+      rosrun_prefix="$2"
       shift
       shift
       ;;
@@ -48,12 +48,14 @@ case $2 in
 esac
 
 if [[ -n $CMAKE_PREFIX_PATH ]]; then
-  catkin_package_libexec_dir=`catkin_find --without-underlays --libexec --share $1 2> /dev/null`
-  debug "Looking in catkin libexec dir: $catkin_package_libexec_dir"
+  IFS=$'\n'
+  catkin_package_libexec_dirs=(`catkin_find --without-underlays --libexec --share "$1" 2> /dev/null`)
+  unset IFS
+  debug "Looking in catkin libexec dirs: $catkin_package_libexec_dirs"
 fi
-pkgdir=`rospack find $1`
+pkgdir=`rospack find "$1"`
 debug "Looking in rospack dir: $pkgdir"
-if [[ -z $catkin_package_libexec_dir && -z $pkgdir ]]; then
+if [[ ${#catkin_package_libexec_dirs[@]} -eq 0 && -z $pkgdir ]]; then
   exit 2
 fi
 if [[ ! $2 == */* ]]; then
@@ -66,15 +68,18 @@ if [[ ! $2 == */* ]]; then
     _perm="/111"
   fi
   debug "Searching for $2 with permissions $_perm"
-  exepathlist=(`find -L $catkin_package_libexec_dir $pkgdir -name $2 -type f  -perm $_perm ! -regex ".*$pkgdir\/build\/.*" | uniq`)
+  exepathlist="`find -L "${catkin_package_libexec_dirs[@]}" "$pkgdir" -name "$2" -type f  -perm "$_perm" ! -regex ".*$pkgdir\/build\/.*" | uniq`"
+  IFS=$'\n'
+  exepathlist=($exepathlist)
+  unset IFS
   unset _perm
   if [[ ${#exepathlist[@]} == 0 ]]; then
     echo "[rosrun] Couldn't find executable named $2 below $pkgdir"
-    nonexepathlist=(`find -H $pkgdir -name $2`)
+    nonexepathlist=(`find -H "$pkgdir" -name "$2"`)
     if [[ ${#nonexepathlist[@]} != 0 ]]; then
       echo "[rosrun] Found the following, but they're either not files,"
       echo "[rosrun] or not executable:"
-      for p in ${nonexepathlist[@]}; do
+      for p in "${nonexepathlist[@]}"; do
         echo "[rosrun]   ${p}"
       done
     fi
@@ -82,23 +87,23 @@ if [[ ! $2 == */* ]]; then
 
   elif [[ ${#exepathlist[@]} -gt 1 ]]; then
     echo "[rosrun] You have chosen a non-unique executable, please pick one of the following:"
-    select opt in ${exepathlist[@]}; do
-      exepath=$opt
+    select opt in "${exepathlist[@]}"; do
+      exepath="$opt"
       break
     done
   else
-    exepath=${exepathlist[0]}
+    exepath="${exepathlist[0]}"
   fi
 else
-  absname=$pkgdir/$2
+  absname="$pkgdir/$2"
   debug "Path given. Looing for $absname"
-  if [ ! -f $absname -o ! -x $absname ]; then
+  if [[ ! -f $absname || ! -x $absname ]]; then
     echo "[rosrun] Couldn't find executable named $absname"
     exit 3
   fi
-  exepath=$absname
+  exepath="$absname"
 fi
 shift
 shift
 debug "Running $rosrun_prefix $exepath" "$@"
-exec $rosrun_prefix $exepath "$@"
+exec $rosrun_prefix "$exepath" "$@"


### PR DESCRIPTION
This PR allows command names and search paths for `rosrun` to contain spaces. It mainly adds quotes around a bunch of variables and sets `IFS=$'\n'` on two places to split only on newlines.

In the case of `$catkin_package_libexec_dr`, I turned it into an array (also by splitting the output with `IFS=$'\n'`, and renamed it to be plural) so the individual elements can contain spaces when passing it to `find`.

I tested with a test packages containing one script with a space in the name:
`rosrun test_package "test script"`

Without the PR, `rosrun` errors out on a `find` command. WIth the PR it works as expected. The same goes for workspace paths containing spaces, previously they would have caused `find` to error, but with the PR it works.

Does not fix #85 but it makes sense to do this first ;)
