### PR TITLE
roszsh: Ignore hidden files and directory in _roscomplete_exe.

### DIFF
--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -344,7 +344,7 @@ function _roscomplete_exe {
     else
         perm="/111"
     fi
-    _roscomplete_search_dir "-type f -perm $perm -regex .*/.*$"
+    _roscomplete_search_dir "-type f -perm $perm -regex .*/.*$ ! -path */\.*"
 }
 
 function _roscomplete_file {


### PR DESCRIPTION
This PR filters hidden files and files in hidden directories from the `_roscomplete_exe` results in zsh (which is used only for `rosrun` completion as far as I could tell).

The reason for filtering them is that it is unlikely a user wants them to show up in the completion suggestions. One specific example is a package that is itself a git repository. These contain a bunch of example git hooks in `.git/hooks/*.sample`. Those hooks are executable files, and it was very annoying to have to mentally filter those out.

Additionally, I replaced `-print0 | tr '\000' '\n'` with a simple `-print`. It seemed a rather contrived way to get newline seperated results (which is the default, even `-print` could be omitted in most cases, but that depends on the passed options so I left it in place).
