### PR TITLE
Expose an api which can map multiple export values to one package name

### DIFF
--- a/core/roslib/include/ros/package.h
+++ b/core/roslib/include/ros/package.h
@@ -108,10 +108,18 @@ ROSLIB_DECL bool getAll(V_string& packages);
 ROSLIB_DECL void getPlugins(const std::string& package, const std::string& attribute, V_string& plugins, bool force_recrawl=false);
 
 /**
+ * \brief Call the "rospack plugins" command, eg. "rospack plugins --attrib=<attribute> <package>".  Returns a pair of vector of strings which
+ * are package names and export values respectively. This allows for multiple values in the one package name.
+ */
+ROSLIB_DECL void getPlugins(const std::string& package, const std::string& attribute, V_string& packages, V_string& plugins, bool force_recrawl=false);
+
+/**
  * \brief Call the "rospack plugins" command, eg. "rospack plugins --attrib=<attribute> <package>".  Returns a map of package name to
  * export value.
+ *
+ * @WARNING if there are multiple export values, only the last one is saved in the map.
  */
-ROSLIB_DECL void getPlugins(const std::string& package, const std::string& attribute, M_string& plugins, bool force_recrawl=false);
+ROS_DEPRECATED ROSLIB_DECL void getPlugins(const std::string& package, const std::string& attribute, M_string& plugins, bool force_recrawl=false);
 
 } // namespace package
 } // namespace ros

--- a/core/roslib/src/package.cpp
+++ b/core/roslib/src/package.cpp
@@ -107,7 +107,7 @@ bool getAll(V_string& packages)
   return true;
 }
 
-static void getPlugins(const std::string& package, const std::string& attribute, V_string& packages, V_string& plugins, bool force_recrawl)
+void getPlugins(const std::string& package, const std::string& attribute, V_string& packages, V_string& plugins, bool force_recrawl)
 {
   if (force_recrawl)
   {


### PR DESCRIPTION
The map based api has a problem - it loses export values when there are more than one per package name (simply overwrites any that were previously stored with the same package name key). This doesn't match the behaviour of rospack from the command line for which it is possible to list up multiple export values for each package name.

I've marked the map based api as deprecated - it really shouldn't be in there if it gives erroneous results, but some folk may be using it.
