### PR TITLE
add ability to load tests using dotnames in rosunit

### DIFF
--- a/tools/rosunit/src/rosunit/pyunit.py
+++ b/tools/rosunit/src/rosunit/pyunit.py
@@ -57,6 +57,8 @@ def unitrun(package, test_name, test, sysargs=None, coverage_packages=None):
     
     @param package: name of ROS package that is running the test
     @type  package: str
+    @param test: a test case instance or a name resolving to a test case or suite
+    @type  test: unittest.TestCase, or string
     @param coverage_packages: list of Python package to compute coverage results for. Defaults to package
     @type  coverage_packages: [str]
     @param sysargs: (optional) alternate sys.argv
@@ -84,7 +86,12 @@ def unitrun(package, test_name, test, sysargs=None, coverage_packages=None):
         start_coverage(coverage_packages)
 
     # create and run unittest suite with our xmllrunner wrapper
-    suite = unittest.TestLoader().loadTestsFromTestCase(test)
+    suite = None
+    if issubclass(test, unittest.TestCase):
+        suite = unittest.TestLoader().loadTestsFromTestCase(test)
+    else:
+        suite = unittest.TestLoader().loadTestsFromName(test)
+
     if text_mode:
         result = unittest.TextTestRunner(verbosity=2).run(suite)
     else:

--- a/tools/rosunit/test/dotname_cases.py
+++ b/tools/rosunit/test/dotname_cases.py
@@ -1,0 +1,36 @@
+import unittest
+
+
+class CaseA(unittest.TestCase):
+
+    def runTest(self):
+        self.assertTrue(True)
+
+
+class CaseB(unittest.TestCase):
+
+    def runTest(self):
+        self.assertTrue(True)
+
+
+class DotnameLoadingSuite(unittest.TestSuite):
+
+    def __init__(self):
+        super(DotnameLoadingSuite, self).__init__()
+        self.addTest(CaseA())
+        self.addTest(CaseB())
+
+
+class DotnameLoadingTest(unittest.TestCase):
+
+    def test_a(self):
+        self.assertTrue(True)
+
+    def test_b(self):
+        self.assertTrue(True)
+
+
+class NotTestCase():
+
+    def not_test(self):
+        pass

--- a/tools/rosunit/test/test_dotname.py
+++ b/tools/rosunit/test/test_dotname.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+# This file should be run using a non-ros unit test framework such as nose using
+# nosetests test_dotname.py. Alternatively, just run with python test_dotname.py.
+# You will get the output from rostest as well.
+
+import unittest
+import rosunit
+from dotname_cases import DotnameLoadingTest, NotTestCase
+
+
+class TestDotnameLoading(unittest.TestCase):
+
+    def test_class_basic(self):
+        rosunit.unitrun('test_rosunit', 'test_class_basic', DotnameLoadingTest)
+
+    def test_class_dotname(self):
+        rosunit.unitrun('test_rosunit', 'test_class_dotname', 'test.dotname_cases.DotnameLoadingTest')
+
+    def test_method_dotname(self):
+        rosunit.unitrun('test_rosunit', 'test_method_dotname', 'test.dotname_cases.DotnameLoadingTest.test_a')
+
+    def test_suite_dotname(self):
+        rosunit.unitrun('test_rosunit', 'test_suite_dotname', 'test.dotname_cases.DotnameLoadingSuite')
+
+    def test_class_basic_nottest(self):
+        # class which exists but is not a TestCase
+        with self.assertRaises(SystemExit):
+            rosunit.unitrun('test_rosunit', 'test_class_basic_nottest', NotTestCase)
+
+    def test_class_dotname_nottest(self):
+        # class which exists but is not a valid test
+        with self.assertRaises(TypeError):
+            rosunit.unitrun('test_rosunit', 'test_class_dotname_nottest', 'test.dotname_cases.NotTestCase')
+
+    def test_class_dotname_noexist(self):
+        # class which does not exist in the module
+        with self.assertRaises(AttributeError):
+            rosunit.unitrun('test_rosunit', 'test_class_dotname_noexist', 'test.dotname_cases.DotnameLoading')
+
+    def test_method_dotname_noexist(self):
+        # method which does not exist in the class
+        with self.assertRaises(AttributeError):
+            rosunit.unitrun('test_rosunit', 'test_method_dotname_noexist', 'test.dotname_cases.DotnameLoadingTest.not_method')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Replaces #101.

Simplify the selection logic and cleanup new Python code.
