### PR TITLE
Fixing a few incorrect method calls in junitxml.py

### DIFF
--- a/tools/rosunit/src/rosunit/junitxml.py
+++ b/tools/rosunit/src/rosunit/junitxml.py
@@ -89,7 +89,7 @@ class TestError(TestInfo):
         @return XML tag representing the object, with non-XML text filtered out
         @rtype: str
         """
-        return ET.tostring(self.xml_element, encoding='utf-8', method='xml')
+        return ET.tostring(self.xml_element(), encoding='utf-8', method='xml')
 
     def xml_element(self):
         """
@@ -110,7 +110,7 @@ class TestFailure(TestInfo):
         @return XML tag representing the object, with non-XML text filtered out
         @rtype: str
         """
-        return ET.tostring(self.xml_element, encoding='utf-8', method='xml')
+        return ET.tostring(self.xml_element(), encoding='utf-8', method='xml')
 
     def xml_element(self):
         """
@@ -200,7 +200,7 @@ class TestCaseResult(object):
         @return XML tag representing the object, with non-XML text filtered out
         @rtype: str
         """
-        return ET.tostring(self.xml_element, encoding='utf-8', method='xml')
+        return ET.tostring(self.xml_element(), encoding='utf-8', method='xml')
 
     def xml_element(self):
         """
@@ -214,7 +214,7 @@ class TestCaseResult(object):
         for f in self.failures:
             testcase.append(f.xml_element())
         for e in self.errors:
-            testcase.append(e.xml())
+            testcase.append(e.xml_element())
         return testcase
         
 class Result(object):

--- a/tools/rosunit/test/test_junitxml.py
+++ b/tools/rosunit/test/test_junitxml.py
@@ -91,6 +91,44 @@ def _writeMockResultFile(result):
         if len(result.suites) > 1 or result.noSuitesRoot == False:
             f.write('</testsuites>\n')
 
+class XmlResultTestGeneration(unittest.TestCase):
+    def setUp(self):
+        global junitxml
+        if junitxml is None:
+            import rosunit.junitxml
+            junitxml = rosunit.junitxml
+
+    def tearDown(self):
+        pass
+
+    def testGenerateError(self):
+        error = junitxml.TestError('error_type', 'error_text')
+        error_str = error.xml()
+        self.assertEquals('''<error type="error_type">&lt;![CDATA[
+error_text
+]]&gt;</error>''', error_str)
+
+    def testGenerateFailure(self):
+        failure = junitxml.TestFailure('failure_type', 'failure_text')
+        failure_str = failure.xml()
+        self.assertEquals('''<failure type="failure_type">&lt;![CDATA[
+failure_text
+]]&gt;</failure>''', failure_str)
+
+    def testGenerateTestCaseResult(self):
+        testcase = junitxml.TestCaseResult('test_case')
+        error = junitxml.TestError('error_type', 'error_text')
+        error_str = error.xml()
+        failure = junitxml.TestFailure('failure_type', 'failure_text')
+        failure_str = failure.xml()
+        testcase.add_error(error)
+        testcase.add_failure(failure)
+        testcase_str = testcase.xml()
+        self.assertEquals('''<testcase classname="" name="test_case" time="0.0"><failure type="failure_type">&lt;![CDATA[
+failure_text
+]]&gt;</failure><error type="error_type">&lt;![CDATA[
+error_text
+]]&gt;</error></testcase>''', testcase_str)
 
 class XmlResultTestRead(unittest.TestCase):
 


### PR DESCRIPTION
@evenator noticed that a few method calls in junitxml.py were missing parentheses, and one place was incorrectly calling xml() instead of xml_element(), so I fixed them.
