### PR TITLE
Correct spelling of 'rosed'

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -259,7 +259,7 @@ function _roscmd {
 function rosed {
     local arg
     if [[ $1 = "--help" ]]; then
-       echo -e "usage: rossed [package] [file]\n\nEdit a file within a package."
+       echo -e "usage: rosed [package] [file]\n\nEdit a file within a package."
        return 0
     fi
     _roscmd ${1} ${2}


### PR DESCRIPTION
Found this misspelling. There are a couple more instances of 'rossed' in this file, but those may be intentional.
