### PR TITLE
Allow custom classname, testcase name in test_xx_junit_xml.

### DIFF
--- a/tools/rosunit/src/rosunit/junitxml.py
+++ b/tools/rosunit/src/rosunit/junitxml.py
@@ -454,7 +454,7 @@ def read_all(filter_=[]):
     return root_result
 
 
-def test_failure_junit_xml(test_name, message, stdout=None, classname="Results"):
+def test_failure_junit_xml(test_name, message, stdout=None, classname="Results", testcasename="test_ran"):
     """
     Generate JUnit XML file for a unary test suite where the test failed
     
@@ -472,7 +472,7 @@ def test_failure_junit_xml(test_name, message, stdout=None, classname="Results")
     testsuite.set('errors', '0')
     testsuite.set('name', test_name)
     testcase = ET.SubElement(testsuite, 'testcase')
-    testcase.set('name', 'test_ran')
+    testcase.set('name', testcasename)
     testcase.set('status', 'run')
     testcase.set('time', '1')
     testcase.set('classname', classname)
@@ -484,7 +484,7 @@ def test_failure_junit_xml(test_name, message, stdout=None, classname="Results")
         system_out.text = cdata(filter_nonprintable_text(stdout))
     return ET.tostring(testsuite, encoding='utf-8', method='xml')
 
-def test_success_junit_xml(test_name, classname="Results"):
+def test_success_junit_xml(test_name, classname="Results", testcasename="test_ran"):
     """
     Generate JUnit XML file for a unary test suite where the test succeeded.
     
@@ -498,7 +498,7 @@ def test_success_junit_xml(test_name, classname="Results"):
     testsuite.set('errors', '0')
     testsuite.set('name', test_name)
     testcase = ET.SubElement(testsuite, 'testcase')
-    testcase.set('name', 'test_ran')
+    testcase.set('name', testcasename)
     testcase.set('status', 'run')
     testcase.set('time', '1')
     testcase.set('classname', classname)

--- a/tools/rosunit/src/rosunit/junitxml.py
+++ b/tools/rosunit/src/rosunit/junitxml.py
@@ -454,7 +454,7 @@ def read_all(filter_=[]):
     return root_result
 
 
-def test_failure_junit_xml(test_name, message, stdout=None):
+def test_failure_junit_xml(test_name, message, stdout=None, classname="Results"):
     """
     Generate JUnit XML file for a unary test suite where the test failed
     
@@ -475,7 +475,7 @@ def test_failure_junit_xml(test_name, message, stdout=None):
     testcase.set('name', 'test_ran')
     testcase.set('status', 'run')
     testcase.set('time', '1')
-    testcase.set('classname', 'Results')
+    testcase.set('classname', classname)
     failure = ET.SubElement(testcase, 'failure')
     failure.set('message', message)
     failure.set('type', '')
@@ -484,7 +484,7 @@ def test_failure_junit_xml(test_name, message, stdout=None):
         system_out.text = cdata(filter_nonprintable_text(stdout))
     return ET.tostring(testsuite, encoding='utf-8', method='xml')
 
-def test_success_junit_xml(test_name):
+def test_success_junit_xml(test_name, classname="Results"):
     """
     Generate JUnit XML file for a unary test suite where the test succeeded.
     
@@ -501,7 +501,7 @@ def test_success_junit_xml(test_name):
     testcase.set('name', 'test_ran')
     testcase.set('status', 'run')
     testcase.set('time', '1')
-    testcase.set('classname', 'Results')
+    testcase.set('classname', classname)
     return ET.tostring(testsuite, encoding='utf-8', method='xml')
 
 def print_summary(junit_results, runner_name='ROSUNIT'):

--- a/tools/rosunit/src/rosunit/junitxml.py
+++ b/tools/rosunit/src/rosunit/junitxml.py
@@ -454,7 +454,7 @@ def read_all(filter_=[]):
     return root_result
 
 
-def test_failure_junit_xml(test_name, message, stdout=None, classname="Results", testcasename="test_ran"):
+def test_failure_junit_xml(test_name, message, stdout=None, class_name="Results", testcase_name="test_ran"):
     """
     Generate JUnit XML file for a unary test suite where the test failed
     
@@ -472,10 +472,10 @@ def test_failure_junit_xml(test_name, message, stdout=None, classname="Results",
     testsuite.set('errors', '0')
     testsuite.set('name', test_name)
     testcase = ET.SubElement(testsuite, 'testcase')
-    testcase.set('name', testcasename)
+    testcase.set('name', testcase_name)
     testcase.set('status', 'run')
     testcase.set('time', '1')
-    testcase.set('classname', classname)
+    testcase.set('classname', class_name)
     failure = ET.SubElement(testcase, 'failure')
     failure.set('message', message)
     failure.set('type', '')
@@ -484,7 +484,7 @@ def test_failure_junit_xml(test_name, message, stdout=None, classname="Results",
         system_out.text = cdata(filter_nonprintable_text(stdout))
     return ET.tostring(testsuite, encoding='utf-8', method='xml')
 
-def test_success_junit_xml(test_name, classname="Results", testcasename="test_ran"):
+def test_success_junit_xml(test_name, class_name="Results", testcase_name="test_ran"):
     """
     Generate JUnit XML file for a unary test suite where the test succeeded.
     
@@ -498,10 +498,10 @@ def test_success_junit_xml(test_name, classname="Results", testcasename="test_ra
     testsuite.set('errors', '0')
     testsuite.set('name', test_name)
     testcase = ET.SubElement(testsuite, 'testcase')
-    testcase.set('name', testcasename)
+    testcase.set('name', testcase_name)
     testcase.set('status', 'run')
     testcase.set('time', '1')
-    testcase.set('classname', classname)
+    testcase.set('classname', class_name)
     return ET.tostring(testsuite, encoding='utf-8', method='xml')
 
 def print_summary(junit_results, runner_name='ROSUNIT'):


### PR DESCRIPTION
With the default value of "Results", tests which use this code (like the roslaunch check) get a very unhelpful description in the Jenkins layout:

<img width="500" alt="screen shot 2016-09-08 at 10 19 35 pm" src="https://cloud.githubusercontent.com/assets/944666/18373477/7dae28cc-7612-11e6-80ec-1d462ba2533b.png">

By specifying the classname as `roslaunch.RoslaunchCheck` and the case name as, eg `test_my_pkg_check_launch`, it would show as originating from the roslaunch package, and be much more identifiable as to what it is checking (similar to rostests being grouped under `rostest.runner`).

This is a no-function change that is just to enable this improved behaviour in the roslaunch check.

@dirk-thomas
