### PR TITLE
Bugfix to allow loading test cases from name

### DIFF
--- a/tools/rosunit/src/rosunit/pyunit.py
+++ b/tools/rosunit/src/rosunit/pyunit.py
@@ -87,10 +87,10 @@ def unitrun(package, test_name, test, sysargs=None, coverage_packages=None):
 
     # create and run unittest suite with our xmllrunner wrapper
     suite = None
-    if issubclass(test, unittest.TestCase):
-        suite = unittest.TestLoader().loadTestsFromTestCase(test)
-    else:
+    if isinstance(test, basestring):
         suite = unittest.TestLoader().loadTestsFromName(test)
+    elif issubclass(test, unittest.TestCase): # throws TypeError if issubclass fails
+        suite = unittest.TestLoader().loadTestsFromTestCase(test)
 
     if text_mode:
         result = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This fixes the problem identified in PR #104. Alternatively could be done by doing the exception handling for `TypeError` if you wish to handle the majority case (class object) first.
