### PR TITLE
Added --size option to rosclean purge

### DIFF
--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -173,15 +173,18 @@ def _rosclean_cmd_purge(args):
             except:
                 print("FAILED to execute command", file=sys.stderr)
         else:
-            print("Purging %s until directory size is at most %d MB."%(label, args.size))
+            files = _sort_file_by_oldest(d)
+            log_size = get_disk_usage(d)
+            if log_size <= args.size * 1024 * 1024:
+                print("Directory size of %s is %d MB which is already below the requested threshold of %d MB."%(label, log_size / 1024 / 1024, args.size))
+                continue
+            print("Purging %s until directory size is at most %d MB (currently %d MB)."%(label, args.size, log_size / 1024 / 1024))
             if not args.y:
                 print("PLEASE BE CAREFUL TO VERIFY THE COMMAND BELOW!")
                 if not _ask("Purge some of old logs in %s"%d):
                     return
-            files = _sort_file_by_oldest(d)
-            log_size = get_disk_usage(d)
             for f in files:
-                if log_size <= args.size * 1000 * 1000:
+                if log_size <= args.size * 1024 * 1024:
                     break
                 path = os.path.join(d, f)
                 log_size -= get_disk_usage(path)

--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -181,7 +181,7 @@ def _rosclean_cmd_purge(args):
             files = _sort_file_by_oldest(d)
             log_size = get_disk_usage(d)
             for f in files:
-                if (log_size <= (args.size * 1000 * 1000) ):
+                if log_size <= args.size * 1000 * 1000:
                     break
                 path = os.path.join(d, f)
                 log_size -= get_disk_usage(path)

--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -53,6 +53,7 @@ def _ask_and_call(cmds, cwd=None):
     :param cwd: (optional) set cwd of command that is executed, ``str``
     :returns: ``True`` if cmds were run.
     """
+    # Pretty-print a string version of the commands
     def quote(s):
         return '"%s"'%s if ' ' in s else s
     sys.stdout.write("Okay to execute:\n\n%s\n(y/n)?\n"%('\n'.join([' '.join([quote(s) for s in c]) for c in cmds])))
@@ -224,7 +225,7 @@ def rosclean_main(argv=None):
     parser_purge = subparsers.add_parser('purge', help='Remove log files')
     parser_purge.set_defaults(func=_rosclean_cmd_purge)
     parser_purge.add_argument('-y', action='store_true', default=False, help='CAUTION: automatically confirms all questions to delete files')
-    parser_purge.add_argument('--size', action='store', default=None, type=int, help='Directory size in MB until deletes old log files.')
+    parser_purge.add_argument('--size', action='store', default=None, type=int, help='Minimum total size to keep when deleting old files')
     args = parser.parse_args(argv[1:])
     args.func(args)
 

--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -53,7 +53,6 @@ def _ask_and_call(cmds, cwd=None):
     :param cwd: (optional) set cwd of command that is executed, ``str``
     :returns: ``True`` if cmds were run.
     """
-    # Pretty-print a string version of the commands
     def quote(s):
         return '"%s"'%s if ' ' in s else s
     sys.stdout.write("Okay to execute:\n\n%s\n(y/n)?\n"%('\n'.join([' '.join([quote(s) for s in c]) for c in cmds])))
@@ -65,6 +64,20 @@ def _ask_and_call(cmds, cwd=None):
     if accepted:
         _call(cmds, cwd)
     return accepted
+
+def _ask(comment):
+    """
+    ask user with provided comment. If user responds with y, return True
+
+    :param comment: comment, ``str``
+    :return: ``True`` if user responds with y
+    """
+    sys.stdout.write("Okey to perform:\n\n%s\n(y/n)?\n"%comment)
+    while 1:
+        input = sys.stdin.readline().strip().lower()
+        if input in ['y', 'n']:
+            break
+    return (input == 'y')
 
 def _call(cmds, cwd=None):
     """
@@ -138,20 +151,68 @@ def get_disk_usage(d):
     else:
         raise CleanupException("rosclean is not supported on this platform")
 
+def _sort_file_by_oldest(d):
+    """
+    Get files and directories in specified path sorted by last modified time
+    :param d: directory path, ```str```
+    :return:  a list of files and directories sorted by last modified time (old first), ```list```
+    """
+    files = os.listdir(d)
+    files.sort(key=lambda file: os.path.getmtime(os.path.join(d,file)))
+    return files
+
+def _check_delete_file_size(d, file):
+    """
+    Get size of specified directory after deleting specified file or directory
+    :param d: directory path, ```str```
+    :param file: file or directory, ```str```
+    :return: size of directory after purging file, ```int```
+    """
+    d_size = get_disk_usage(d)
+    target = os.path.join(d, file)
+    if os.path.isdir(target):
+        files = os.listdir(target)
+        f_size = 0
+        for f in files:
+            f_size = f_size + os.path.getsize(os.path.join(target, f))
+    else:
+        f_size = os.path.getsize(target)
+    return (d_size - f_size)
+
 def _rosclean_cmd_purge(args):
     dirs = _get_check_dirs()
 
     for d, label in dirs:
-        print("Purging %s."%label)
-        cmds = [['rm', '-rf', d]]
-        try:
-            if args.y:
-                _call(cmds)
-            else:
+        if not args.size:
+            print("Purging %s."%label)
+            cmds = [['rm', '-rf', d]]
+            try:
+                if args.y:
+                    _call(cmds)
+                else:
+                    print("PLEASE BE CAREFUL TO VERIFY THE COMMAND BELOW!")
+                    _ask_and_call(cmds)
+            except:
+                print("FAILED to execute command", file=sys.stderr)
+        else:
+            print("Purging %s until directory size is %d MB."%(label, args.size))
+            if not args.y:
                 print("PLEASE BE CAREFUL TO VERIFY THE COMMAND BELOW!")
-                _ask_and_call(cmds)
-        except:
-            print("FAILED to execute command", file=sys.stderr)
+                exe = _ask("Purge some of old logs in %s"%d)
+            else:
+                exe = True
+            if exe:
+                files = _sort_file_by_oldest(d)
+                for file in files:
+                    if _check_delete_file_size(d, file) >= (args.size * 1024 * 1024):
+                        name = d + '/' + file
+                        cmds = [['rm', '-rf', name]]
+                        try:
+                            _call(cmds)
+                        except:
+                            print("FAILED to execute command", file=sys.stderr)
+                    else:
+                        break
 
 def rosclean_main(argv=None):
     if argv is None:
@@ -163,6 +224,7 @@ def rosclean_main(argv=None):
     parser_purge = subparsers.add_parser('purge', help='Remove log files')
     parser_purge.set_defaults(func=_rosclean_cmd_purge)
     parser_purge.add_argument('-y', action='store_true', default=False, help='CAUTION: automatically confirms all questions to delete files')
+    parser_purge.add_argument('--size', action='store', default=None, type=int, help='Directory size in MB until deletes old log files.')
     args = parser.parse_args(argv[1:])
     args.func(args)
 


### PR DESCRIPTION
This pull request adds "--size" option to "rosclean purge", which allows user to specify minimum total size in MB to keep when deleting old files. When "--size" option is specified, old log files (based on last modified time) will be deleted until reaches specified minimum total size.

Example Usage
```bash
rosclean purge --size 200
```