### PR TITLE
roslib: add rospack to CATKIN_DEPENDS (#128)

### DIFF
--- a/core/roslib/CMakeLists.txt
+++ b/core/roslib/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(catkin REQUIRED COMPONENTS rospack)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES roslib
+  CATKIN_DEPENDS rospack
   CFG_EXTRAS roslib-extras.cmake)
 
 find_package(Boost REQUIRED COMPONENTS thread)


### PR DESCRIPTION
This fixes a linker issue that can arise on some build environments:

    ld: warning: librospack.so, needed by /opt/ros/indigo/lib/libroslib.so, not found (try using -rpath or -rpath-link)
    /opt/ros/indigo/lib/libroslib.so: undefined reference to `rospack::ROSPack::run(std::string const&)'
    collect2: error: ld returned 1 exit status

If everything is ok, I would be interested in having this cherry-picked to indigo, which is where I have the issue, and jade too for completeness.