### PR TITLE
[rostopic] Rostopic pub autocomplete's now works when options are provided

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -776,14 +776,40 @@ function _roscomplete_rostopic {
 										COMPREPLY=($(compgen -W "$opts" -- ${arg}))
 										;;
 								pub)
-										if [[ $COMP_CWORD == 2 ]]; then
+										topic_pos=0
+										type_pos=0
+										msg_pos=0
+										
+										COUNTER=2
+										while [ $COUNTER -lt ${#COMP_WORDS[*]} ]; do
+											if [[ ${COMP_WORDS[$COUNTER]} == -r ]]; then
+												if [[ COUNTER -lt ${#COMP_WORDS[*]} ]]; then
+													(( COUNTER += 1 ))
+													if ! [[ ${COMP_WORDS[$COUNTER]} =~ [0-9]+ ]]; then
+														(( COUNTER -= 1 ))
+													fi
+												fi
+											elif ! [[ ${COMP_WORDS[$COUNTER]} =~ \-.* ]]; then
+												if [ $topic_pos == 0 ]; then
+													topic_pos=$COUNTER
+												elif [ $type_pos == 0 ]; then
+													type_pos=$COUNTER
+												elif [ $msg_pos == 0 ]; then
+													msg_pos=$COUNTER
+													break
+												fi
+											fi
+											(( COUNTER += 1 ))
+										done
+										
+										if [[ $COMP_CWORD == $topic_pos ]]; then
 												opts=`rostopic list 2> /dev/null`
 												COMPREPLY=($(compgen -W "$opts" -- ${arg}))
-										elif [[ $COMP_CWORD == 3 ]]; then
+										elif [[ $COMP_CWORD == $type_pos ]]; then
 												opts=`_msg_opts ${COMP_WORDS[$COMP_CWORD]}`
 												COMPREPLY=($(compgen -W "$opts" -- ${arg}))
-								    elif [[ $COMP_CWORD == 4 ]]; then
-								    		opts=`rosmsg-proto msg 2> /dev/null -s ${COMP_WORDS[3]}`
+								    elif [[ $COMP_CWORD == $msg_pos ]]; then
+								    		opts=`rosmsg-proto msg 2> /dev/null -s ${COMP_WORDS[$type_pos]}`
 												if [ 0 -eq $? ]; then
 													COMPREPLY="$opts"
 												fi


### PR DESCRIPTION
If a user uses the autocomplete option (pressing the TAB key) while using "rostopic pub" with options, the autocomplete function assumes that the options provided were arguments. This leads the function to provide the wrong arguments to autocomplete.

For example: "rostopic pub --once (TAB)" provides a list of message types instead of a list of topics.

This PR solves this problem by differentiating between options and arguments