### PR TITLE
[rostopic] Rostopic pub autocompletes the topic type

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -780,7 +780,14 @@ function _roscomplete_rostopic {
 												opts=`rostopic list 2> /dev/null`
 												COMPREPLY=($(compgen -W "$opts" -- ${arg}))
 										elif [[ $COMP_CWORD == 3 ]]; then
-												opts=`_msg_opts ${COMP_WORDS[$COMP_CWORD]}`
+												opts=${COMP_WORDS[$COMP_CWORD]}
+												info=`rostopic info $opts 2> /dev/null`
+												info=(${info[@]})
+												if [ "${info[0]}" == Type: ]; then
+													opts=${info[1]}
+												else
+													opts=`_msg_opts ${COMP_WORDS[$COMP_CWORD]}`
+												fi
 												COMPREPLY=($(compgen -W "$opts" -- ${arg}))
 								    elif [[ $COMP_CWORD == 4 ]]; then
 								    		opts=`rosmsg-proto msg 2> /dev/null -s ${COMP_WORDS[3]}`


### PR DESCRIPTION
Despite the topic type being static, the autocomplete function (pressing TAB) doesn't provide it, but instead provides the whole list of types.

With this PR the autocomplete function uses the given topic name to search the corresponding type to autocomplete. If the topic wasn't declared beforehand, it provides the whole list as always.

Edited:
This solution has another implementation (#125). However, that solution uses awk to parse the topic information and that seems to be slower than this implementation because it only uses bash operations to do the parsing.