### PR TITLE
don't hide error strings from the reader

### DIFF
--- a/tools/rosunit/src/rosunit/core.py
+++ b/tools/rosunit/src/rosunit/core.py
@@ -103,9 +103,9 @@ def xml_results_file(test_pkg, test_name, is_rostest=False, env=None):
     if not os.path.exists(test_dir):
         try:
             makedirs_with_parent_perms(test_dir)
-        except OSError:
-            raise IOError("cannot create test results directory [%s]. Please check permissions."%(test_dir))
-        
+        except OSError as error:
+            raise IOError("cannot create test results directory [%s]: %s"%(test_dir, str(error)))
+
     # #576: strip out chars that would bork the filename
     # this is fairly primitive, but for now just trying to catch some common cases
     for c in ' "\'&$!`/\\':
@@ -153,8 +153,8 @@ def create_xml_runner(test_pkg, test_name, results_file=None, is_rostest=False):
     if not os.path.exists(test_dir):
         try:
             makedirs_with_parent_perms(test_dir) #NOTE: this will pass up an error exception if it fails
-        except OSError:
-            raise IOError("cannot create test results directory [%s]. Please check permissions."%(test_dir))
+        except OSError as error:
+            raise IOError("cannot create test results directory [%s]: %s"%(test_dir, str(error)))
 
     elif os.path.isfile(test_dir):
         raise Exception("ERROR: cannot run test suite, file is preventing creation of test dir: %s"%test_dir)


### PR DESCRIPTION
Over at MoveIt, we currently have a nondeterministically broken travis (see https://github.com/ros-planning/moveit/issues/311).
The issue at hand makes it harder to understand the source of the problem.

It would be great to see this improved and released soon :)

This except-and-raise pattern hides the actual error messages and leaves
us with a generic string "cannot create test results..." instead.
This makes it much harder to track down bugs.

On the other hand the exception text "[Errno 13] Permission denied: 'foobar'"
alone does not tell you that "foobar" is supposed to be the directory for the
tests results.

Thus I fused both exception texts. Because the error message in case of
missing permissions is (given above) "Permission denied", I removed the
"Please check permissions." hint.