### PR TITLE
[rosunit] More searchable testcase result message.

### DIFF
--- a/tools/rosunit/src/rosunit/xmlrunner.py
+++ b/tools/rosunit/src/rosunit/xmlrunner.py
@@ -86,7 +86,7 @@ class _TestInfo(object):
         #        "method": self._method,
         #        "time": self._time,
         #    })
-        stream.write(self._method)
+        stream.write('[Testcase: ' + self._method + ']')
         if self._failure != None:
             stream.write(' ... FAILURE!\n')
             self._print_error_text(stream, 'failure', self._failure)


### PR DESCRIPTION
Printed message of the result of each testcase/testmethod? is hard to find when browsing through the test result. Example below:
```
:
[ INFO] [1487343289.092146469]: Constructing FaceDetector.
[ INFO] [1487343289.537363058]: You must subscribe to one of FaceDetector's outbound topics or else it will not publish anything.
Error opening rosout log file '/root/.ros/07335a6c-f521-11e6-a2a7-0242ac110002/rosout.log': No such file or directoryError opening rosout log file '/root/.ros/07335a6c-f521-11e6-a2a7-0242ac110002/rosout.log': No such file or directoryWaiting for service /wide_stereo/driver/set_parameters...
hztest_withface_/face_detector/faces_cloud ... ok

[ROSTEST]-----------------------------------------------------------------------
:
```

(This example is easier.)

This PR makes the result line(s) stand out more, also text-searchable.