### PR TITLE
changes between 1.12.7 and 1.13.5 for backporting

### DIFF
--- a/core/roslib/CMakeLists.txt
+++ b/core/roslib/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(catkin REQUIRED COMPONENTS rospack)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES roslib
+  CATKIN_DEPENDS rospack
   CFG_EXTRAS roslib-extras.cmake)
 
 find_package(Boost REQUIRED COMPONENTS thread)

--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -259,7 +259,7 @@ function _roscmd {
 function rosed {
     local arg
     if [[ $1 = "--help" ]]; then
-       echo -e "usage: rossed [package] [file]\n\nEdit a file within a package."
+       echo -e "usage: rosed [package] [file]\n\nEdit a file within a package."
        return 0
     fi
     _roscmd ${1} ${2}

--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -800,11 +800,11 @@ function _roscomplete_rosservice {
     arg="${COMP_WORDS[COMP_CWORD]}"
 
     if [[ $COMP_CWORD == 1 ]]; then
-        opts="list call type find uri"
+        opts="args call find info list type uri"
         COMPREPLY=($(compgen -W "$opts" -- ${arg}))
     elif [[ $COMP_CWORD == 2 ]]; then
         case ${COMP_WORDS[1]} in
-            uri|list|type|call)
+            args|call|info|list|type|uri)
                 opts=`rosservice list 2> /dev/null`
                 COMPREPLY=($(compgen -W "$opts" -- ${arg}))                
                 ;;

--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -780,7 +780,10 @@ function _roscomplete_rostopic {
 												opts=`rostopic list 2> /dev/null`
 												COMPREPLY=($(compgen -W "$opts" -- ${arg}))
 										elif [[ $COMP_CWORD == 3 ]]; then
-												opts=`_msg_opts ${COMP_WORDS[$COMP_CWORD]}`
+                                                                                                opts=$(rostopic info ${COMP_WORDS[$COMP_CWORD-1]} 2> /dev/null | awk '/Type:/{print $2}')
+                                                                                                if [ -z "$opts" ]; then
+                                                                                                        opts=`_msg_opts ${COMP_WORDS[$COMP_CWORD]}`
+                                                                                                fi
 												COMPREPLY=($(compgen -W "$opts" -- ${arg}))
 								    elif [[ $COMP_CWORD == 4 ]]; then
 								    		opts=`rosmsg-proto msg 2> /dev/null -s ${COMP_WORDS[3]}`

--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -577,11 +577,11 @@ function _roscomplete_rosservice {
 
 
     if [[ ${CURRENT} == 2 ]]; then
-        opts="list call type find uri"
+        opts="args call find info list type uri"
         reply=(${=opts})
     elif [[ ${CURRENT} == 3 ]]; then
         case ${words[2]} in
-            uri|list|type|call)
+            args|call|info|list|type|uri)
                 opts=`rosservice list 2> /dev/null`
                 IFS=$'\n'
                 reply=(${=opts})

--- a/tools/rosunit/package.xml
+++ b/tools/rosunit/package.xml
@@ -8,8 +8,8 @@
   <license>BSD</license>
 
   <url type="website">http://ros.org/wiki/rosunit</url>
-  <url type="bugtracker">https://github.com/ros/ros_comm/issues</url>
-  <url type="repository">https://github.com/ros/ros_comm</url>
+  <url type="bugtracker">https://github.com/ros/ros/issues</url>
+  <url type="repository">https://github.com/ros/ros</url>
   <author>Ken Conley</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>

--- a/tools/rosunit/src/rosunit/core.py
+++ b/tools/rosunit/src/rosunit/core.py
@@ -103,9 +103,9 @@ def xml_results_file(test_pkg, test_name, is_rostest=False, env=None):
     if not os.path.exists(test_dir):
         try:
             makedirs_with_parent_perms(test_dir)
-        except OSError:
-            raise IOError("cannot create test results directory [%s]. Please check permissions."%(test_dir))
-        
+        except OSError as error:
+            raise IOError("cannot create test results directory [%s]: %s"%(test_dir, str(error)))
+
     # #576: strip out chars that would bork the filename
     # this is fairly primitive, but for now just trying to catch some common cases
     for c in ' "\'&$!`/\\':
@@ -153,8 +153,8 @@ def create_xml_runner(test_pkg, test_name, results_file=None, is_rostest=False):
     if not os.path.exists(test_dir):
         try:
             makedirs_with_parent_perms(test_dir) #NOTE: this will pass up an error exception if it fails
-        except OSError:
-            raise IOError("cannot create test results directory [%s]. Please check permissions."%(test_dir))
+        except OSError as error:
+            raise IOError("cannot create test results directory [%s]: %s"%(test_dir, str(error)))
 
     elif os.path.isfile(test_dir):
         raise Exception("ERROR: cannot run test suite, file is preventing creation of test dir: %s"%test_dir)

--- a/tools/rosunit/src/rosunit/core.py
+++ b/tools/rosunit/src/rosunit/core.py
@@ -32,6 +32,7 @@
 
 from __future__ import print_function
 
+import errno
 import os
 import sys
 import logging
@@ -74,7 +75,11 @@ def makedirs_with_parent_perms(p):
     if not os.path.exists(p) and p and parent != p:
         makedirs_with_parent_perms(parent)
         s = os.stat(parent)
-        os.mkdir(p)
+        try:
+            os.mkdir(p)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
         # if perms of new dir don't match, set anew
         s2 = os.stat(p)

--- a/tools/rosunit/src/rosunit/pyunit.py
+++ b/tools/rosunit/src/rosunit/pyunit.py
@@ -87,7 +87,7 @@ def unitrun(package, test_name, test, sysargs=None, coverage_packages=None):
 
     # create and run unittest suite with our xmllrunner wrapper
     suite = None
-    if issubclass(test, unittest.TestCase):
+    if isinstance(test, unittest.TestCase):
         suite = unittest.TestLoader().loadTestsFromTestCase(test)
     else:
         suite = unittest.TestLoader().loadTestsFromName(test)

--- a/tools/rosunit/src/rosunit/pyunit.py
+++ b/tools/rosunit/src/rosunit/pyunit.py
@@ -87,10 +87,11 @@ def unitrun(package, test_name, test, sysargs=None, coverage_packages=None):
 
     # create and run unittest suite with our xmllrunner wrapper
     suite = None
-    if isinstance(test, unittest.TestCase):
-        suite = unittest.TestLoader().loadTestsFromTestCase(test)
-    else:
+    if isinstance(test, str):
         suite = unittest.TestLoader().loadTestsFromName(test)
+    else:
+        # some callers pass a TestCase type (instead of an instance)
+        suite = unittest.TestLoader().loadTestsFromTestCase(test)
 
     if text_mode:
         result = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
The following list of changes has been integrated into ros 1.13.5 (Kinetic) since the last Jade release (1.12.7).

**Backported:** (these changes are part of this PR)

* add missing completion for rosservice verbs #117

  * fix bug

* fix usage spelling #118

  * fix bug

* fix check test type #123

  * fix bug

* improve rostopic pub completion #125

  * nice to have improvement

* missing exported dependency #129

  * fix bug

* fix race condition creating folder #130

  * fix bug

* fix url in metainfo #133

  * fix bug

* improve error message #134

  * nice to have improvement

**Not backported:**

* rosbuild stacks on RPP #111

  * change of semantic, not being backported

* enable more unit tests #113

  * no need to backport

* allow custom unit test names #119

  * new feature, no need to backport

* allow ROS_DISTRO override #122

  * new feature, no need to backport

* rosclean purge --size #126

  * new feature, no need to backport

* rostopic pub completion with options #136

  * new feature, bigger change -> higher risk, no need to backport

* rosmg info completion #138.

  * corresponding change in `ros_comm` won't be backported

@ros/ros_team Please comment on the decision which changes to (not) backport.