### PR TITLE
allow arguments in EDITOR env in zsh rosed

### DIFF
--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -249,7 +249,7 @@ function rosed {
     if [[ -z $EDITOR ]]; then
         vim ${arg}
     else
-        $EDITOR ${arg}
+        eval $EDITOR ${arg}
     fi
 }
 


### PR DESCRIPTION
in zsh executing
$EDITOR ${arg}
fails if EDITOR has space in it (as zsh escapes the content),
e.g. EDITOR='emacs -nw' becomes 'emacs\ -nw'