### PR TITLE
Updates to roslib.packages.find_resources

### DIFF
--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -510,7 +510,9 @@ def find_resource(pkg, resource_name, filter_fn=None, rospack=None):
     for search_path in search_paths:
         matches.extend(_find_resource(search_path, resource_name, filter_fn=filter_fn))
 
-    matches.extend(_find_resource(pkg_path, resource_name, filter_fn=filter_fn))
+    # Only search ROS_PACKAGE_PATH if not matched in binary build dirs.
+    if not matches:
+        matches.extend(_find_resource(pkg_path, resource_name, filter_fn=filter_fn))
 
     # Uniquify the results, in case we found the same file twice, while keeping order
     unique_matches = []

--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -475,7 +475,6 @@ def find_resource(pkg, resource_name, filter_fn=None, rospack=None):
         returns True if the it matches the desired resource, ``fn(str)``
     :param rospack: `rospkg.RosPack` instance to use
     :returns: lists of matching paths for resource within a given scope, ``[str]``
-    :raises: :exc:`rospkg.ResourceNotFound` If package does not exist 
     """
 
     # New resource-location policy in Fuerte, induced by the new catkin 


### PR DESCRIPTION
Make the code fully comply with the documented behavior to not search the source tree after a successful find in the binary dir. 

And remove the documentation of a raise on not found as it returns an empty list. 