### PR TITLE
add runtime dependency on VIM as it is the default rosed editor

### DIFF
--- a/tools/rosbash/package.xml
+++ b/tools/rosbash/package.xml
@@ -14,4 +14,5 @@
   <buildtool_depend version_gte="0.5.72">catkin</buildtool_depend>
 
   <run_depend>catkin</run_depend>
+  <run_depend>vim</run_depend>
 </package>


### PR DESCRIPTION
`rosed` assumes vim installed if `EDITOR` not set

`rosbash` currently doesn't depend on any editor. But [defaults to vim if no `EDITOR` is specified](https://github.com/ros/ros/blob/9585a2904b245a64fd27064a4932c004e96644d8/tools/rosbash/rosbash#L268).
Currently our docker images don't install vim so rosed is not usable out of the box.