### PR TITLE
rosrun: array is now properly expanded in debug-echo

### DIFF
--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -51,7 +51,7 @@ if [[ -n $CMAKE_PREFIX_PATH ]]; then
   IFS=$'\n'
   catkin_package_libexec_dirs=($(catkin_find --without-underlays --libexec --share "$1" 2> /dev/null))
   unset IFS
-  debug "Looking in catkin libexec dirs: $catkin_package_libexec_dirs"
+  debug "Looking in catkin libexec dirs: ${catkin_package_libexec_dirs[*]}"
 fi
 pkgdir=$(rospack find "$1")
 debug "Looking in rospack dir: $pkgdir"


### PR DESCRIPTION
The previous version printed (uninteded?) only the first entry of the array.