### PR TITLE
add missing dependencies

### DIFF
--- a/core/roslib/package.xml
+++ b/core/roslib/package.xml
@@ -23,6 +23,8 @@
   <run_depend>ros_environment</run_depend>
   <run_depend>rospack</run_depend>
 
+  <test_depend>rosmake</test_depend>
+
   <export>
      <rosdoc config="${prefix}/rosdoc.yaml" />
   </export>

--- a/tools/roscreate/package.xml
+++ b/tools/roscreate/package.xml
@@ -16,4 +16,5 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <run_depend>python-rospkg</run_depend>
+  <run_depend>roslib</run_depend>
 </package>


### PR DESCRIPTION
* The `roslib` tests expect `rosmake`: https://github.com/ros/ros/blob/33b74d57a71a11c46df6f95108b80b3f4241aaa5/core/roslib/test/test_roslib_stacks.py#L175
* `roscreate` uses `roslib`: https://github.com/ros/ros/blob/33b74d57a71a11c46df6f95108b80b3f4241aaa5/tools/roscreate/src/roscreate/roscreatepkg.py#L42