### PR TITLE
rosclean: support BusyBox du

### DIFF
--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -135,10 +135,10 @@ def get_disk_usage(d):
     :raises: :exc:`CleanupException` If get_disk_usage() cannot be used on this platform
     """
     # only implemented on Linux and FreeBSD for now. Should work on OS X but need to verify first (du is not identical)
-    cmd = []
+    cmd = None
     unit = 1
     du = find_executable('du')
-    if du != None:
+    if du is not None:
         if platform.system() == 'Linux':
             cmd = [du, '-sb', d]
         elif platform.system() == 'FreeBSD':
@@ -152,7 +152,7 @@ def get_disk_usage(d):
         except:
             pass
 
-    if cmd == []:
+    if cmd is None:
         raise CleanupException("rosclean is not supported on this platform")
     try:
         return int(subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0].split()[0]) * unit

--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -34,6 +34,7 @@ from __future__ import print_function
 
 __version__ = '1.7.0'
 
+from distutils.spawn import find_executable
 import argparse
 import os
 import sys
@@ -134,17 +135,28 @@ def get_disk_usage(d):
     :raises: :exc:`CleanupException` If get_disk_usage() cannot be used on this platform
     """
     # only implemented on Linux and FreeBSD for now. Should work on OS X but need to verify first (du is not identical)
-    if platform.system() == 'Linux':
+    cmd = []
+    unit = 1
+    du = find_executable('du')
+    if du != None:
+        if platform.system() == 'Linux':
+            cmd = [du, '-sb', d]
+        elif platform.system() == 'FreeBSD':
+            cmd = [du, '-skA', d]
+            unit = 1024
         try:
-            return int(subprocess.Popen(['du', '-sb', d], stdout=subprocess.PIPE).communicate()[0].split()[0])
+            # detect BusyBox du command by following symlink
+            if os.path.basename(os.readlink(du)) == 'busybox':
+                cmd = [du, '-sk', d]
+                unit = 1024
         except:
-            raise CleanupException("rosclean is not supported on this platform")
-    elif platform.system() == 'FreeBSD':
-        try:
-            return int(subprocess.Popen(['du', '-sA', d], stdout=subprocess.PIPE).communicate()[0].split()[0]) * 1024
-        except:
-            raise CleanupException("rosclean is not supported on this platform")
-    else:
+            pass
+
+    if cmd == []:
+        raise CleanupException("rosclean is not supported on this platform")
+    try:
+        return int(subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0].split()[0]) * unit
+    except:
         raise CleanupException("rosclean is not supported on this platform")
 
 def _sort_file_by_oldest(d):

--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -149,7 +149,8 @@ def get_disk_usage(d):
             if os.path.basename(os.readlink(du)) == 'busybox':
                 cmd = [du, '-sk', d]
                 unit = 1024
-        except:
+        except OSError:
+            # readlink raises OSError if the target is not symlink
             pass
 
     if cmd is None:


### PR DESCRIPTION
related to #76

On BusyBox based Linux like Alpine, `rosclean.get_disk_usage` fails like below:

```shell
# roslaunch ./test.launch 
... logging to /root/.ros/log/e5ae4876-9249-11e8-822c-0242ac110003/roslaunch-b940bafd7c81-1082.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
du: unrecognized option: b
BusyBox v1.27.2 (2018-06-06 09:08:44 UTC) multi-call binary.

Usage: du [-aHLdclsxhmk] [FILE]...

Summarize disk space used for each FILE and/or directory

	-a	Show file sizes too
	-L	Follow all symlinks
	-H	Follow symlinks on command line
	-d N	Limit output to directories (and files with -a) of depth < N
	-c	Show grand total
	-l	Count sizes many times if hard linked
	-s	Display only a total for each argument
	-x	Skip directories on different filesystems
	-h	Sizes in human readable format (e.g., 1K 243M 2G)
	-m	Sizes in megabytes
	-k	Sizes in kilobytes (default)
```

This PR explicitly detects BusyBox du command by following symlink.
The behavior for non-busybox system is not changed.

I tested it on Alpine (BusyBox du) and Ubuntu (coreutils du) Linux.

### roslaunch on Alpine Linux (BusyBox)

900MB file in ~/.ros/log/
```shell
# dd if=/dev/zero of=/root/.ros/log/test.img bs=900M count=1
# roslaunch ./test.launch 
... logging to /root/.ros/log/ce49ae52-9242-11e8-94bf-0242ac110003/roslaunch-b940bafd7c81-454.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.
```

1GB file in ~/.ros/log/
```shell
# dd if=/dev/zero of=/root/.ros/log/test.img bs=1G count=1
# roslaunch ./test.launch 
... logging to /root/.ros/log/c68c9b5c-9242-11e8-8845-0242ac110003/roslaunch-b940bafd7c81-364.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/root/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.
```

### roslaunch on Ubuntu Linux (coreutils)

900MB file in ~/.ros/log/
```shell
# dd if=/dev/zero of=/root/.ros/log/test.img bs=900M count=1
# roslaunch test.launch
... logging to /root/.ros/log/ea9b124e-9238-11e8-a591-0242ac110002/roslaunch-c0cc32ef0053-4976.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.
```

1GB file in ~/.ros/log/
```shell
# dd if=/dev/zero of=/root/.ros/log/test.img bs=1G count=1
# roslaunch test.launch
... logging to /root/.ros/log/ea9b124e-9238-11e8-a591-0242ac110002/roslaunch-c0cc32ef0053-5028.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/root/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.
```