### PR TITLE
Fix build issue on Windows

### DIFF
--- a/core/roslib/test/package.cpp
+++ b/core/roslib/test/package.cpp
@@ -31,7 +31,6 @@
 
 #include <gtest/gtest.h>
 #include <ros/package.h>
-#include <sys/time.h>
 
 using namespace ros;
 


### PR DESCRIPTION
Add setenv helper function when built for Windows.
Use portable boost::filesystem to create temporary path in set_env_vars()
Use boost::this_thread::sleep in roslib_caller() when run on Windows