### PR TITLE
rosunit python 3 support

### DIFF
--- a/tools/rosunit/src/rosunit/xmlrunner.py
+++ b/tools/rosunit/src/rosunit/xmlrunner.py
@@ -199,7 +199,8 @@ class _XMLTestResult(unittest.TestResult):
         output and standard error streams must be passed in.a
 
         """
-        stream.write(ET.tostring(self.xml(time_taken, out, err).getroot(), encoding='utf-8', method='xml'))
+        root = self.xml(time_taken, out, err).getroot()
+        stream.write(ET.tostring(root, encoding='utf-8', method='xml').decode('utf-8'))
 
     def print_report_text(self, stream, time_taken, out, err):
         """Prints the text report to the supplied stream.

--- a/tools/rosunit/test/test_xmlrunner.py
+++ b/tools/rosunit/test/test_xmlrunner.py
@@ -4,7 +4,7 @@
 # nosetests test_dotname.py. Alternatively, just run with python test_dotname.py.
 # You will get the output from rostest as well.
 
-# Original code for xmlrunner written by Sebastian Rittau
+# Original code for xmlrunner written by Sebastian Rittau 
 # <srittau@jroger.in-berlin.de> and placed in the Public Domain.
 # With contributions by Paolo Borelli.
 # These tests refactored into a separate package by Edward Venator.
@@ -18,7 +18,6 @@ try:
 except ImportError:
     from io import StringIO
 from rosunit.xmlrunner import XMLTestRunner
-
 
 class XMLTestRunnerTest(unittest.TestCase):
     def setUp(self):
@@ -51,7 +50,7 @@ class XMLTestRunnerTest(unittest.TestCase):
     def test_no_tests(self):
         """Regression test: Check whether a test run without any tests
         matches a previous run.
-
+        
         """
         class TestTest(unittest.TestCase):
             pass
@@ -60,7 +59,7 @@ class XMLTestRunnerTest(unittest.TestCase):
     def test_success(self):
         """Regression test: Check whether a test run with a successful test
         matches a previous run.
-
+        
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
@@ -72,7 +71,7 @@ class XMLTestRunnerTest(unittest.TestCase):
     def test_failure(self):
         """Regression test: Check whether a test run with a failing test
         matches a previous run.
-
+        
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
@@ -84,7 +83,7 @@ class XMLTestRunnerTest(unittest.TestCase):
     def test_error(self):
         """Regression test: Check whether a test run with a erroneous test
         matches a previous run.
-
+        
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
@@ -96,7 +95,7 @@ class XMLTestRunnerTest(unittest.TestCase):
     def test_stdout_capture(self):
         """Regression test: Check whether a test run with output to stdout
         matches a previous run.
-
+        
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
@@ -108,7 +107,7 @@ class XMLTestRunnerTest(unittest.TestCase):
     def test_stderr_capture(self):
         """Regression test: Check whether a test run with output to stderr
         matches a previous run.
-
+        
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
@@ -152,7 +151,6 @@ class XMLTestProgram(unittest.TestProgram):
         if self.testRunner is None:
             self.testRunner = XMLTestRunner()
         unittest.TestProgram.runTests(self)
-
 
 main = XMLTestProgram
 

--- a/tools/rosunit/test/test_xmlrunner.py
+++ b/tools/rosunit/test/test_xmlrunner.py
@@ -4,7 +4,7 @@
 # nosetests test_dotname.py. Alternatively, just run with python test_dotname.py.
 # You will get the output from rostest as well.
 
-# Original code for xmlrunner written by Sebastian Rittau 
+# Original code for xmlrunner written by Sebastian Rittau
 # <srittau@jroger.in-berlin.de> and placed in the Public Domain.
 # With contributions by Paolo Borelli.
 # These tests refactored into a separate package by Edward Venator.
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from io import StringIO
 from rosunit.xmlrunner import XMLTestRunner
+
 
 class XMLTestRunnerTest(unittest.TestCase):
     def setUp(self):
@@ -45,66 +46,76 @@ class XMLTestRunnerTest(unittest.TestCase):
         got = re.sub(r'(?s)<failure (.*?)>.*?</failure>', r'<failure \1>Foobar</failure>', got)
         got = re.sub(r'(?s)<error (.*?)>.*?</error>', r'<error \1>Foobar</error>', got)
 
-        self.assertEqual(expected, got)
+        self.assertIn(got, expected)
 
     def test_no_tests(self):
         """Regression test: Check whether a test run without any tests
         matches a previous run.
-        
+
         """
         class TestTest(unittest.TestCase):
             pass
-        self._try_test_run(TestTest, """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="0" time="0.000"><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>""")
+        self._try_test_run(TestTest, ["""<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="0" time="0.000"><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>"""])
 
     def test_success(self):
         """Regression test: Check whether a test run with a successful test
         matches a previous run.
-        
+
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
                 pass
-        self._try_test_run(TestTest, """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000" /><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>""")
+        py2_expected = """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000" /><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>"""
+        py3_expected = py2_expected.replace('TestTest', 'XMLTestRunnerTest.test_success.&lt;locals&gt;.TestTest')
+        self._try_test_run(TestTest, [py2_expected, py3_expected])
 
     def test_failure(self):
         """Regression test: Check whether a test run with a failing test
         matches a previous run.
-        
+
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
                 self.assert_(False)
-        self._try_test_run(TestTest, """<testsuite errors="0" failures="1" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000"><failure type="AssertionError">Foobar</failure></testcase><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>""")
+        py2_expected = """<testsuite errors="0" failures="1" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000"><failure type="AssertionError">Foobar</failure></testcase><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>"""
+        py3_expected = py2_expected.replace('TestTest', 'XMLTestRunnerTest.test_failure.&lt;locals&gt;.TestTest')
+        self._try_test_run(TestTest, [py2_expected, py3_expected])
 
     def test_error(self):
         """Regression test: Check whether a test run with a erroneous test
         matches a previous run.
-        
+
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
                 raise IndexError()
-        self._try_test_run(TestTest, """<testsuite errors="1" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000"><error type="IndexError">Foobar</error></testcase><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>""")
+        py2_expected = """<testsuite errors="1" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000"><error type="IndexError">Foobar</error></testcase><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>"""
+        py3_expected = py2_expected.replace('TestTest', 'XMLTestRunnerTest.test_error.&lt;locals&gt;.TestTest')
+        self._try_test_run(TestTest, [py2_expected, py3_expected])
 
     def test_stdout_capture(self):
         """Regression test: Check whether a test run with output to stdout
         matches a previous run.
-        
+
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
                 print("Foo > Bar")
-        self._try_test_run(TestTest, """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000" /><system-out>&lt;![CDATA[\nFoo &gt; Bar\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>""")
+        py2_expected = """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000" /><system-out>&lt;![CDATA[\nFoo &gt; Bar\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\n\n]]&gt;</system-err></testsuite>"""
+        py3_expected = py2_expected.replace('TestTest', 'XMLTestRunnerTest.test_stdout_capture.&lt;locals&gt;.TestTest')
+        self._try_test_run(TestTest, [py2_expected, py3_expected])
 
     def test_stderr_capture(self):
         """Regression test: Check whether a test run with output to stderr
         matches a previous run.
-        
+
         """
         class TestTest(unittest.TestCase):
             def test_foo(self):
                 print("Foo > Bar", file=sys.stderr)
-        self._try_test_run(TestTest, """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000" /><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\nFoo &gt; Bar\n\n]]&gt;</system-err></testsuite>""")
+        py2_expected = """<testsuite errors="0" failures="0" name="unittest.suite.TestSuite" tests="1" time="0.000"><testcase classname="test.test_xmlrunner.TestTest" name="test_foo" time="0.000" /><system-out>&lt;![CDATA[\n\n]]&gt;</system-out><system-err>&lt;![CDATA[\nFoo &gt; Bar\n\n]]&gt;</system-err></testsuite>"""
+        py3_expected = py2_expected.replace('TestTest', 'XMLTestRunnerTest.test_stderr_capture.&lt;locals&gt;.TestTest')
+        self._try_test_run(TestTest, [py2_expected, py3_expected])
 
     class NullStream(object):
         """A file-like object that discards everything written to it."""
@@ -141,6 +152,7 @@ class XMLTestProgram(unittest.TestProgram):
         if self.testRunner is None:
             self.testRunner = XMLTestRunner()
         unittest.TestProgram.runTests(self)
+
 
 main = XMLTestProgram
 


### PR DESCRIPTION
Address ros#158 by explicitly decoding to utf-8 before writing to stream.

This is a typical Python 2 -> 3 issue. Before this fix, Python 2 would return a `str` and Python 3 would return `bytes`. `bytes` is not supported for writing to streams like stdout in Python 3.

This fix explicitly decodes to utf-8 before writing, so in Python 2 we're writing a `unicode` object and in Python 3 we're writing a `str` object.