### PR TITLE
use _MSC_VER for ROS_FORCE_INLINE

### DIFF
--- a/core/roslib/include/ros/package.h
+++ b/core/roslib/include/ros/package.h
@@ -36,7 +36,7 @@
 #if defined(__GNUC__)
 #  define ROS_DEPRECATED __attribute__((deprecated))
 #  define ROS_FORCE_INLINE __attribute__((always_inline))
-#elif defined(MSVC)
+#elif defined(_MSC_VER)
 #  define ROS_DEPRECATED
 #  define ROS_FORCE_INLINE __forceinline
 #else


### PR DESCRIPTION
unify the use of macros:
use the `_MSC_VER` macro instead of the `MSVC` macro just like [line 52](https://github.com/ros/ros/blob/kinetic-devel/core/roslib/include/ros/package.h#L52) in the same file