### PR TITLE
special handle python script without extension on Windows

### DIFF
--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -406,7 +406,7 @@ def _executable_filter(test_path):
     # Python scripts in ROS tend to omit .py extension since they could become executable
     # by adding a shebang line (#!/usr/bin/env python) in Linux environments
     # special handle this case in Windows environment
-    if os.name == 'nt' and os.path.splitext(test_path)[1] in ['.py', '']:
+    if os.name == 'nt' and os.path.splitext(test_path)[1].lower() in ['.py', '']:
         flags = stat.S_IRUSR
     return (s.st_mode & flags) == flags
 

--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -403,8 +403,8 @@ def _executable_filter(test_path):
     s = os.stat(test_path)
     flags = stat.S_IRUSR | stat.S_IXUSR
 
-    # python scripts in ROS tend to omit .py extension since they could become executable
-    # by adding a shebang line (#!/usr/bin/env python) in linux environment
+    # Python scripts in ROS tend to omit .py extension since they could become executable
+    # by adding a shebang line (#!/usr/bin/env python) in Linux environments
     # special handle this case in Windows environment
     if os.name == 'nt' and os.path.splitext(test_path)[1] in ['.py', '']:
         flags = stat.S_IRUSR

--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -404,7 +404,8 @@ def _executable_filter(test_path):
     flags = stat.S_IRUSR | stat.S_IXUSR
     if os.name == 'nt':
         _, ext = os.path.splitext(test_path)
-        # python scripts in ROS tend to omit .py extension since they are natively executable in linux environment
+        # python scripts in ROS tend to omit .py extension since they could become executable
+        # by adding a shebang line (#!/usr/bin/env python) in linux environment
         # special handle this case in Windows environment
         if ext.lower() in ['.py', '']:
             flags = stat.S_IRUSR

--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -402,13 +402,12 @@ def find_node(pkg, node_type, rospack=None):
 def _executable_filter(test_path):
     s = os.stat(test_path)
     flags = stat.S_IRUSR | stat.S_IXUSR
-    if os.name == 'nt':
-        _, ext = os.path.splitext(test_path)
-        # python scripts in ROS tend to omit .py extension since they could become executable
-        # by adding a shebang line (#!/usr/bin/env python) in linux environment
-        # special handle this case in Windows environment
-        if ext.lower() in ['.py', '']:
-            flags = stat.S_IRUSR
+
+    # python scripts in ROS tend to omit .py extension since they could become executable
+    # by adding a shebang line (#!/usr/bin/env python) in linux environment
+    # special handle this case in Windows environment
+    if os.name == 'nt' and os.path.splitext(test_path)[1] in ['.py', '']:
+        flags = stat.S_IRUSR
     return (s.st_mode & flags) == flags
 
 def _find_resource(d, resource_name, filter_fn=None):

--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -402,8 +402,12 @@ def find_node(pkg, node_type, rospack=None):
 def _executable_filter(test_path):
     s = os.stat(test_path)
     flags = stat.S_IRUSR | stat.S_IXUSR
-    if os.name == 'nt' and os.path.splitext(test_path)[1] == '.py':
-        flags = stat.S_IRUSR
+    if os.name == 'nt':
+        _, ext = os.path.splitext(test_path)
+        # python scripts in ROS tend to omit .py extension since they are natively executable in linux environment
+        # special handle this case in Windows environment
+        if ext.lower() in ['.py', '']:
+            flags = stat.S_IRUSR
     return (s.st_mode & flags) == flags
 
 def _find_resource(d, resource_name, filter_fn=None):


### PR DESCRIPTION
python scripts in ROS tend to omit `.py` extension since they could become executable by adding a shebang line:
```
#!/usr/bin/env python
```
in linux environment

special handle this case in Windows environment