### PR TITLE
fall back to default value if modules are not available

### DIFF
--- a/tools/rosmake/src/rosmake/engine.py
+++ b/tools/rosmake/src/rosmake/engine.py
@@ -256,9 +256,9 @@ class Printer:
                 s = struct.pack('HHHH', 0, 0, 0, 0)
                 x = fcntl.ioctl(1, termios.TIOCGWINSZ, s)
                 width = struct.unpack('HHHH', x)[1]
-            except IOError:
-                pass
             except ImportError:
+                pass
+            except IOError:
                 pass
             if width <= 0:
                 try:

--- a/tools/rosmake/src/rosmake/engine.py
+++ b/tools/rosmake/src/rosmake/engine.py
@@ -258,6 +258,8 @@ class Printer:
                 width = struct.unpack('HHHH', x)[1]
             except IOError:
                 pass
+            except ImportError:
+                pass
             if width <= 0:
                 try:
                     width = int(os.environ['COLUMNS'])


### PR DESCRIPTION
`fcntl` is not available on Windows, leading to exception in [`terminal_width()`](https://github.com/ros/ros/blob/kinetic-devel/tools/rosmake/src/rosmake/engine.py#L251)

while it sounds like a Windows-specific issue, yet we are trying to resolve it in a generic way:
if any of the modules (`struct`, `fcntl`, `termios`) are not available, fall back to default value for terminal width