### PR TITLE
add ${PYTHON_EXECUTABLE} to ROSUNIT_EXE

### DIFF
--- a/tools/rosunit/cmake/rosunit-extras.cmake.em
+++ b/tools/rosunit/cmake/rosunit-extras.cmake.em
@@ -4,11 +4,11 @@ macro(rosunit_initialize_tests)
 @[if DEVELSPACE]@
   # binary and script in develspace
   set(ROSUNIT_SCRIPTS_DIR "@(CMAKE_CURRENT_SOURCE_DIR)/scripts")
-  set(ROSUNIT_EXE "${ROSUNIT_SCRIPTS_DIR}/rosunit")
+  set(ROSUNIT_EXE "${PYTHON_EXECUTABLE} ${ROSUNIT_SCRIPTS_DIR}/rosunit")
 @[else]@
   # binary and script in installspace
   set(ROSUNIT_SCRIPTS_DIR "${rosunit_DIR}/../scripts")
-  set(ROSUNIT_EXE "${rosunit_DIR}/../../../@(CATKIN_GLOBAL_BIN_DESTINATION)/rosunit")
+  set(ROSUNIT_EXE "${PYTHON_EXECUTABLE} ${rosunit_DIR}/../../../@(CATKIN_GLOBAL_BIN_DESTINATION)/rosunit")
 @[end if]@
 endmacro()
 


### PR DESCRIPTION
python scripts could be directly executed on Linux thanks to the help of the shebang line, so most of the times the `${PYTHON_EXECUTABLE}` prefix is ignored; however, python scripts are not executable on Windows (without extra setup), so the prefix is needed (it wouldn't hurt)