### PR TITLE
disable test with invalid dependency

### DIFF
--- a/core/roslib/test/test_roslib_stacks.py
+++ b/core/roslib/test/test_roslib_stacks.py
@@ -41,8 +41,9 @@ class RoslibStacksTest(unittest.TestCase):
   
     def test_list_stacks(self):
         from roslib.stacks import list_stacks
-        l = list_stacks()
-        self.assert_('ros' in l)
+        # roslib can't depend on ros and therefore can't expect it being in the environment
+        # l = list_stacks()
+        # self.assert_('ros' in l)
 
         # test with env
         test_dir = os.path.join(roslib.packages.get_pkg_dir('roslib'), 'test', 'stack_tests', 's1')


### PR DESCRIPTION
The `roslib` test can't expect that the package `ros` is available since it doesn't declare a dependency on that package. (It also can't declare that dependency since the `ros` metapackage depends on `roslib`.)