### PR TITLE
correct findpath script name in batch scripts

### DIFF
--- a/tools/rosbash/scripts/roscd.bat
+++ b/tools/rosbash/scripts/roscd.bat
@@ -22,7 +22,7 @@ if "%1" equ "" (
     exit /b 1
 )
 
-for /f "tokens=*" %%g in ('call python %~dp0\findpath.py %1 forceeval') do (
+for /f "tokens=*" %%g in ('call python %~dp0\rosfindpath.py %1 forceeval') do (
     set target_path=%%~g
 )
 

--- a/tools/rosbash/scripts/rosls.bat
+++ b/tools/rosbash/scripts/rosls.bat
@@ -1,7 +1,7 @@
 @echo off
 
 if "%1" equ "--help" goto :usage
-for /f "tokens=*" %%g in ('call python %~dp0\findpath.py %1 forceeval') do (
+for /f "tokens=*" %%g in ('call python %~dp0\rosfindpath.py %1 forceeval') do (
     set target_path=%%~g
 )
 


### PR DESCRIPTION
`findpath.py` was renamed to `rosfindpath.py` during previous upstreaming processes, and the batch scripts were not changed to reference the new name.

special thanks to @bakerhillpins for reporting this issue in https://github.com/ms-iot/ROSOnWindows/issues/92

not related to this pull request, but one of the open tasks in our backlog is to implement an Azure-pipeline-based CI for Windows, so issues like this would be caught earlier. My apologies for the bug.