### PR TITLE
fix rosclean, use rd on Windows

### DIFF
--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -190,7 +190,10 @@ def _rosclean_cmd_purge(args):
     for d, label in dirs:
         if not args.size:
             print("Purging %s."%label)
-            cmds = [['rm', '-rf', d]]
+            if platform.system() == 'Windows':
+                cmds = [['rd', '/s', '/q', d]]
+            else:
+                cmds = [['rm', '-rf', d]]
             try:
                 if args.y:
                     _call(cmds)


### PR DESCRIPTION
copy fix from https://github.com/ros/ros/blob/kinetic-devel/tools/rosclean/src/rosclean/__init__.py#L218, use `rd /s /q` on Windows

thanks for root-causing this issue, @c650

this addresses https://github.com/ms-iot/ROSOnWindows/issues/111