### PR TITLE
[roslib] Symlink search for roslib

### DIFF
--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -447,7 +447,7 @@ def _find_resource(d, resource_name, filter_fn=None):
             for x in to_prune:
                 dirs.remove(x)
     else: #UNIX            
-        for p, dirs, files in os.walk(d,followlinks=True):
+        for p, dirs, files in os.walk(d, followlinks=True):
             if resource_name in files:
                 test_path = os.path.join(p, resource_name)
                 if filter_fn is not None:

--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -447,7 +447,7 @@ def _find_resource(d, resource_name, filter_fn=None):
             for x in to_prune:
                 dirs.remove(x)
     else: #UNIX            
-        for p, dirs, files in os.walk(d):
+        for p, dirs, files in os.walk(d,followlinks=True):
             if resource_name in files:
                 test_path = os.path.join(p, resource_name)
                 if filter_fn is not None:


### PR DESCRIPTION
Allowing for finding resources symbolically linked in packages. We needed this for using `roslaunch` with directories linked from other locations, but it will likely be useful in general.