### PR TITLE
Include FreeBSD in platform-dependent argument for `find -perm`

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -520,7 +520,7 @@ function _roscomplete_search_dir {
 
 function _roscomplete_exe {
     local perm i prev_arg
-    if [[ $(uname) == Darwin ]]; then
+    if [[ $(uname) == Darwin || $(uname) == FreeBSD ]]; then
         perm="+111"
     else
         perm="/111"

--- a/tools/rosbash/rosfish
+++ b/tools/rosbash/rosfish
@@ -537,7 +537,7 @@ end
 
 function _roscomplete_rosrun
     set -l perm
-    if test (uname) = "Darwin"
+    if test (uname) = "Darwin" -o (uname) = "FreeBSD"
         set perm "+111"
     else
         set perm "/111"

--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -362,7 +362,7 @@ function _roscomplete_search_dir {
 
 function _roscomplete_exe {
     local perm
-    if [[ `uname` == Darwin ]]; then
+    if [[ `uname` == Darwin || `uname` == FreeBSD ]]; then
         perm="+111"
     else
         perm="/111"

--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -61,10 +61,10 @@ if [[ ${#catkin_package_libexec_dirs[@]} -eq 0 && -z $pkgdir ]]; then
   exit 2
 fi
 if [[ ! $2 == */* ]]; then
-  # The -perm /mode usage is not available in find on the Mac
+  # The -perm /mode usage is not available in find on the Mac or FreeBSD
   #exepathlist=(`find $pkgdir -name $2 -type f -perm /u+x,g+x,o+x`)
   # -L: #3475
-  if [[ $(uname) == Darwin ]]; then
+  if [[ $(uname) == Darwin || $(uname) == FreeBSD ]]; then
     _perm="+111"
   else
     _perm="/111"


### PR DESCRIPTION
FreeBSD doesn't support `find -perm /111`.  Like MacOS (Darwin), it supports `find -perm +111`.

This PR adds FreeBSD to the existing conditional statements that check for Darwin before deciding whether to use `/111` or `+111`.

This is related to issues #33 and #37.