### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/core/roslib/package.xml
+++ b/core/roslib/package.xml
@@ -22,6 +22,8 @@
   <depend>rospack</depend>
 
   <buildtool_depend version_gte="0.6.7">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>boost</build_depend>
 

--- a/core/roslib/setup.py
+++ b/core/roslib/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/tools/rosboost_cfg/package.xml
+++ b/tools/rosboost_cfg/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosboost_cfg</name>
   <version>1.14.7</version>
   <description>
@@ -11,4 +15,6 @@
   <author>Josh Faust</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 </package>

--- a/tools/rosboost_cfg/setup.py
+++ b/tools/rosboost_cfg/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/tools/rosclean/package.xml
+++ b/tools/rosclean/package.xml
@@ -17,6 +17,8 @@
   <author>Ken Conley</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>

--- a/tools/rosclean/setup.py
+++ b/tools/rosclean/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/tools/roscreate/package.xml
+++ b/tools/roscreate/package.xml
@@ -20,6 +20,8 @@
   <author email="kwc@willowgarage.com">Ken Conley</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>

--- a/tools/roscreate/setup.py
+++ b/tools/roscreate/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/tools/rosmake/package.xml
+++ b/tools/rosmake/package.xml
@@ -18,6 +18,8 @@
   <author email="tfoote@osrfoundation.org">Tully Foote</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>

--- a/tools/rosmake/setup.py
+++ b/tools/rosmake/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/tools/rosunit/package.xml
+++ b/tools/rosunit/package.xml
@@ -17,6 +17,8 @@
   <author>Ken Conley</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</exec_depend>

--- a/tools/rosunit/setup.py
+++ b/tools/rosunit/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
On Debian Buster and Ubuntu Focal [distutils has been split to a separate package](https://packages.debian.org/buster/python3-setuptools). With https://github.com/ros/catkin/pull/1048 catkin will prefer to use `setuptools` instead of `distutils`. This PR switches to `setuptools` to match catkin's preference. It uses conditional dependencies so it still works when `ROS_PYTHON_VERSION` is 2 to enable the target branch to be released to earlier ROS distros than Noetic.