### PR TITLE
restrict boost dependencies to components used

### DIFF
--- a/core/roslib/CMakeLists.txt
+++ b/core/roslib/CMakeLists.txt
@@ -38,6 +38,7 @@ catkin_install_python(PROGRAMS scripts/gendeps
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(Boost REQUIRED COMPONENTS filesystem thread)
   catkin_add_nosetests(test)
 
   catkin_add_gtest(${PROJECT_NAME}-utest test/utest.cpp WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/core/roslib/package.xml
+++ b/core/roslib/package.xml
@@ -25,13 +25,14 @@
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
   <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
 
   <exec_depend>catkin</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2" version_gte="1.0.37">python-rospkg</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3" version_gte="1.0.37">python3-rospkg</exec_depend>
   <exec_depend>ros_environment</exec_depend>
 
+  <test_depend>libboost-filesystem-dev</test_depend>
   <test_depend>rosmake</test_depend>
 
   <export>


### PR DESCRIPTION
May be worth targeting to a noetic-devel to not impact released packages on other distributions

related to https://github.com/ros/ros_comm/pull/1871