### PR TITLE
Fix missing rosunit results in Python 3

### DIFF
--- a/tools/rosunit/src/rosunit/xmlrunner.py
+++ b/tools/rosunit/src/rosunit/xmlrunner.py
@@ -265,10 +265,9 @@ class XMLTestRunner(object):
 
         time_taken = time.time() - start_time
         result.print_report(stream, time_taken, out_s, err_s)
+        stream.flush()
 
         result.print_report_text(sys.stdout, time_taken, out_s, err_s)
-
-        stream.flush()
 
         return result
 

--- a/tools/rosunit/src/rosunit/xmlrunner.py
+++ b/tools/rosunit/src/rosunit/xmlrunner.py
@@ -268,6 +268,8 @@ class XMLTestRunner(object):
 
         result.print_report_text(sys.stdout, time_taken, out_s, err_s)
 
+        stream.flush()
+
         return result
 
     def _set_path(self, path):


### PR DESCRIPTION
Sometimes rosunit does not write results to its results file.  This happens when:
* Running the test in Python 3.
* A test has failed.
* Only a few tests were run.

[Typical usage of this method by rostest](https://github.com/ros/ros_comm/blob/melodic-devel/tools/rostest/src/rostest/__init__.py#L146) never explicitly closes the file descriptor.  Python's behavior in this case is undefined and the buffered data can be lost in CPython 3.6.9 (as shipped in the melodic docker image).

By explicitly flushing we guarantee that data from this test is written before we return.