### PR TITLE
fix size output of 'rosclean check' with Python 3 with Python 3

### DIFF
--- a/tools/rosclean/src/rosclean/__init__.py
+++ b/tools/rosclean/src/rosclean/__init__.py
@@ -139,7 +139,7 @@ def get_human_readable_disk_usage(d):
     # only implemented on Linux and FreeBSD for now. Should work on OS X but need to verify first (du is not identical)
     if platform.system() in ['Linux', 'FreeBSD']:
         try:
-            return subprocess.Popen(['du', '-sh', d], stdout=subprocess.PIPE).communicate()[0].split()[0]
+            return subprocess.Popen(['du', '-sh', d], stdout=subprocess.PIPE).communicate()[0].split()[0].decode()
         except Exception:
             raise CleanupException('rosclean is not supported on this platform')
     elif platform.system() == 'Windows':


### PR DESCRIPTION
Without the patch `rosclean check` shows a bytes string:

> b'116K' ROS node logs