### PR TITLE
remove encode/decode from roscreate-pkg with Python 3

### DIFF
--- a/tools/roscreate/src/roscreate/roscreatepkg.py
+++ b/tools/roscreate/src/roscreate/roscreatepkg.py
@@ -98,7 +98,7 @@ def create_package(package, author, depends, uses_roscpp=False, uses_rospy=False
         contents = instantiate_template(template, package, package, package, author, depends)
         p = os.path.abspath(os.path.join(package, filename))
         with open(p, 'w') as f:
-            f.write(contents.encode('utf-8'))
+            f.write(contents)
             print('Created package file', p)
     print('\nPlease edit %s/manifest.xml and mainpage.dox to finish creating your package' % package)
 
@@ -131,6 +131,4 @@ def roscreatepkg_main():
 
     if not on_ros_path(os.getcwd()):
         print('!'*80+'\nWARNING: current working directory is not on ROS_PACKAGE_PATH!\nPlease update your ROS_PACKAGE_PATH environment variable.\n'+'!'*80, file=sys.stderr)
-    if type(package) == str:
-        package = package.decode('utf-8')
     create_package(package, author_name(), depends, uses_roscpp=uses_roscpp, uses_rospy=uses_rospy)

--- a/tools/roscreate/src/roscreate/roscreatepkg.py
+++ b/tools/roscreate/src/roscreate/roscreatepkg.py
@@ -97,8 +97,8 @@ def create_package(package, author, depends, uses_roscpp=False, uses_rospy=False
     for filename, template in templates.items():
         contents = instantiate_template(template, package, package, package, author, depends)
         p = os.path.abspath(os.path.join(package, filename))
-        with open(p, 'w') as f:
-            f.write(contents)
+        with open(p, 'wb') as f:
+            f.write(contents.encode('utf-8'))
             print('Created package file', p)
     print('\nPlease edit %s/manifest.xml and mainpage.dox to finish creating your package' % package)
 


### PR DESCRIPTION
Without the patch roscreate-pkg shows AttributeError: 'str' object has no attribute 'decode'