### PR TITLE
fix ros_location_find with Python 3

### DIFF
--- a/tools/rosbash/scripts/rosfindpath.py
+++ b/tools/rosbash/scripts/rosfindpath.py
@@ -23,13 +23,13 @@ def ros_location_find(package_name):
 
     if package_name == 'log':
         p = subprocess.Popen('roslaunch-logs', stdout=subprocess.PIPE)
-        result_location = p.communicate()[0].strip()
+        result_location = p.communicate()[0].decode().strip()
         result_code = p.returncode
         return result_code, result_location if result_code == 0 else ''
 
     if package_name == 'test_results':
         p = subprocess.Popen('rosrun.bat rosunit test_results_dir.py', stdout=subprocess.PIPE)
-        result_location = p.communicate()[0].strip()
+        result_location = p.communicate()[0].decode().strip()
         result_code = p.returncode
         return result_code, result_location if result_code == 0 else ''
 
@@ -37,13 +37,13 @@ def ros_location_find(package_name):
     env = os.environ
     env[ROS_CACHE_TIMEOUT_ENV_NAME] = '-1.0'
     p = subprocess.Popen(['rospack', 'find', package_name], stdout=subprocess.PIPE)
-    result_location = p.communicate()[0].strip()
+    result_location = p.communicate()[0].decode().strip()
     result_code = p.returncode
     if result_code == 0:
         return result_code, result_location
 
     p = subprocess.Popen(['rosstack', 'find', package_name], stdout=subprocess.PIPE)
-    result_location = p.communicate()[0].strip()
+    result_location = p.communicate()[0].decode().strip()
     result_code = p.returncode
     if result_code == 0:
         return result_code, result_location


### PR DESCRIPTION
Since Python 3, the `subprocess.Popen` has a text/non-text mode which decides the data type to use for `communicate`.

Source: https://docs.python.org/3.8/library/subprocess.html#subprocess.Popen.communicate
> If streams were opened in text mode, input must be a string. Otherwise, it must be bytes.

And without extra conversion, the `rosfindpath.py` will fail with the following trackback:

```
Traceback (most recent call last):
  File "c:\opt\ros\noetic\x64\bin\\rosfindpath.py", line 82, in <module>
    sys.exit(findpathmain(sys.argv[1:]))
  File "c:\opt\ros\noetic\x64\bin\\rosfindpath.py", line 74, in findpathmain
    rosdir = os.path.normpath(os.path.sep.join([package_dir, reldir]))
TypeError: sequence item 0: expected str instance, bytes found
```

This pull request is try to use [`decode()`](https://docs.python.org/3/library/stdtypes.html#bytes.decode) to convert it back to `str` to make it type correct.

This fix was motivated by the issue reported here: https://github.com/ms-iot/ROSOnWindows/issues/248

