### PR TITLE
Fix variable name (from $arg to $argv) in rosfish

### DIFF
--- a/tools/rosbash/rosfish
+++ b/tools/rosbash/rosfish
@@ -22,7 +22,7 @@ function _rosfind
         # BSD find needs -E for extended regexp
         find -E $argv
     else
-        find $arg
+        find $argv
     end
 end
 


### PR DESCRIPTION
Completion does not work well due to this bug.

ref: https://github.com/ros/ros/pull/262