### PR TITLE
roszsh: fix rosmv completion

### DIFF
--- a/tools/rosbash/roszsh
+++ b/tools/rosbash/roszsh
@@ -787,51 +787,15 @@ function _roscomplete_roscreate_pkg {
 }
 
 function _roscomplete_filemv {
-    _roscompletemv_search_dir "-type f ! -regex .*[.][oa]$"
-}
-
-function _roscompletemv_search_dir {
-    local arg opts rosvals
-    COMPREPLY=()
-    arg="${COMP_WORDS[COMP_CWORD]}"
-    option="$(echo -e "${COMP_WORDS[1]}" | tr -d '[:space:]')"
-    if [[ $COMP_CWORD == 2 && ( $option == "-d" ) ]] || [[ $COMP_CWORD == 1 ]]; then
+    local words
+    words=(${=BUFFER})
+    if [[ $CURRENT == 3 && ( $words[2] == "-d" ) ]] || [[ $CURRENT == 2 ]]; then
         # complete packages
-        _roscomplete_pkg "${arg}"
-    elif [[ $COMP_CWORD == 2  && ( $option != "-d" ) ]]; then
-        # complete files within package according to $1
-        _roscomplete_find "${1}" "${COMP_WORDS[1]}" "${arg}"
-    else
-       # complete filenames
-       arg=$(echo ${arg} | sed -e "s|~|$HOME|g")
-        if [[ $arg =~ ^/*.+/.* ]]; then
-           path=${arg%/*}
-        else
-           path=.
-        fi
-        if [[ -e ${path} ]]; then
-           opts=$(find -L $path -maxdepth 1 -type d ! -regex ".*/[.][^./].*" ! -regex "^[.]/" -print0 | tr '\000' '\n' | sed -e "s/$/\//g" -e "s/^[.]\///g" -e "s/'/\\\\\'/g" -e "s/ /\\\\\ /g")$'\n'$(find -L $path -maxdepth 1 -type f ! -regex ".*/[.][^.]*" ! -regex "^[.]/" -print0 | tr '\000' '\n' | sed -e "s/^[.]\///g"  -e "s/'/\\\\\'/g" -e "s/ /\\\\\ /g")
-        else
-           opts=""
-        fi
-        _rosbash_roscomplete_search_dir_IFS="$IFS"
-        IFS=$'\n'
-        COMPREPLY=($(compgen -W "$opts" -- ${arg}))
-        IFS="$_rosbash_roscomplete_search_dir_IFS"
-        unset _rosbash_roscomplete_search_dir_IFS
-        if [[ ${#COMPREPLY[*]} = 1 ]]; then
-            newpath=${COMPREPLY[0]%/*}
-            if [[ -d ${newpath} ]]; then
-               opts=$(find -L $newpath -maxdepth 1 -type d ! -regex ".*/[.][^./].*" ! -regex "^[.]/" -print0 | tr '\000' '\n' | sed -e "s/$/\//g" -e "s/^[.]\///g" -e "s/'/\\\\\'/g" -e "s/ /\\\\\ /g")$'\n'$(find -L $newpath -maxdepth 1 -type f ! -regex ".*/[.][^.]*" ! -regex "^[.]/" -print0 | tr '\000' '\n' | sed -e "s/^[.]\///g"  -e "s/'/\\\\\'/g" -e "s/ /\\\\\ /g")
-               _rosbash_roscomplete_search_dir_IFS="$IFS"
-               IFS=$'\n'
-               COMPREPLY=($(compgen -W "$opts" -- ${arg}))
-               IFS="$_rosbash_roscomplete_search_dir_IFS"
-               unset _rosbash_roscomplete_search_dir_IFS
-            fi
-        fi
+        _roscomplete
+    elif [[ $CURRENT == 3  && ( $words[1] != "-d" ) ]]; then
+        # complete files within package
+        _roscomplete_file
     fi
-
 }
 
 compctl -K "_roscomplete_sub_dir" -S / "roscd" "rospd" "rosls"
@@ -839,7 +803,7 @@ compctl -K "_roscomplete_rosmake" "rosmake"
 
 compctl -x 'p[1]' -k "(check purge)" -- "rosclean"
 compctl -f -x 'p[1]' -K "_roscomplete" - 'p[2]' -K _roscomplete_file -- "rosed" "roscp" "roscat"
-compctl -f -x 'p[1]' -K "_roscomplete_filemv" -- "rosmv"
+compctl -f -x 'p[1,2]' -K "_roscomplete_filemv" -- "rosmv"
 compctl -f -x 'S[-]' -k '(--debug --prefix)' - 'c[-1,--prefix][-1,-p]' -h '' - 'p[1],c[-1,-d],c[-1,--debug],c[-2,-p],c[-2,--prefix]' -K "_roscomplete" - 'p[2],c[-2,-d],c[-2,--debug],c[-3,-p],c[-3,--prefix]' -K _roscomplete_exe -- "rosrun"
 compctl -/g '*.(launch|test)' -x 'p[1]' -K "_roscomplete" -tx - 'p[2]' -K _roscomplete_launchfile - 'p[3,20]' -K _roscomplete_launchfile_args -S ':=' -- + -x 'S[--]' -k "(--files --args --nodes --find-node --child --local --screen --server_uri --run_id --wait --port --core --pid --dump-params --disable-title --help --numworkers --ros-args --skip-log-check --timeout)" -- "roslaunch"
 compctl -/g '*.(launch|test)' -x 'p[1]' -K "_roscomplete" -tx - 'p[2]' -K _roscomplete_launchfile -- + -x 'S[--]' -k "(--bare --bare-limit --bare-name --pkgdir --package)" -- "rostest"


### PR DESCRIPTION
The current completion for `rosmv` and zsh is just a copy of the bash completion. It does not work and instead sets the `$path` variable, which is used internally by zsh instead of `$PATH`, so that the current shell cannot be used further. This PR fixes the completion by calling the functions that already exist (`_roscomplete` and `_roscomplete_file`) for package and package file completion and using the zsh-internal file completion instead of rewriting it.