### PR TITLE
fixed hidden workspace tab complete issue

### DIFF
--- a/tools/rosbash/rosbash
+++ b/tools/rosbash/rosbash
@@ -483,11 +483,20 @@ function _roscomplete_find {
         catkin_package_libexec_dir=$(catkin_find --first-only --without-underlays --libexec ${pkg} 2> /dev/null)
     fi
     pkgdir=$(_ros_package_find ${pkg})
+    
+    dot_check=".*/[.][^./].*"
+
     if [[ -n "$catkin_package_libexec_dir" || -n "$pkgdir" ]]; then
-        opts=$(_rosfind -L $catkin_package_libexec_dir "$pkgdir" ${1} ! -regex ".*/[.][^./].*" ! -regex ".*$pkgdir\/build\/.*"  -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g")
+	#checks if there is a hidden file within catkin_package_libexec_dir or pkgdir
+        if [[ ($catkin_package_libexec_dir =~ $dot_check) || ($pkgdir =~ $dot_check) ]]; then
+            opts=$(_rosfind -L $catkin_package_libexec_dir "$pkgdir" ${1} ! -regex "$dot_check$dot_check" ! -regex ".*$pkgdir\/build\/.*"  -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g")
+        else
+            opts=$(_rosfind -L $catkin_package_libexec_dir "$pkgdir" ${1} ! -regex "dot_check" ! -regex ".*$pkgdir\/build\/.*"  -print0 | tr '\000' '\n' | sed -e "s/.*\/\(.*\)/\1/g")
+        fi
     else
         opts=""
     fi
+    
     _rosbash_roscomplete_find_IFS="$IFS"
     IFS=$'\n'
     COMPREPLY=($(compgen -W "${opts}" -- ${arg}))


### PR DESCRIPTION
Fixed the issue with a hidden workspace as described in #295. This basically checks the executable's directory path or the path  to the directory containing the cpp file, and only allows tab complete if there are 0 or 1 periods in the path. This allows the root directory of the catkin workspace to be a hidden file.