### PR TITLE
Refactor rosbash.fish with fish compatible syntax

### DIFF
--- a/tools/rosbash/env-hooks/15.rosbash.fish.em
+++ b/tools/rosbash/env-hooks/15.rosbash.fish.em
@@ -1,10 +1,10 @@
 # generated from rosbash/env-hooks/15.rosbash.fish.em
 
 @[if DEVELSPACE]@
-. "@(CMAKE_CURRENT_SOURCE_DIR)/rosfish"
+source "@(CMAKE_CURRENT_SOURCE_DIR)/rosfish"
 @[else]@
-if [ -z "$CATKIN_ENV_HOOK_WORKSPACE" ]; then
-  CATKIN_ENV_HOOK_WORKSPACE="@(CMAKE_INSTALL_PREFIX)"
-fi
-. "$CATKIN_ENV_HOOK_WORKSPACE/share/rosbash/rosfish"
+if test -z "$CATKIN_ENV_HOOK_WORKSPACE"
+    set CATKIN_ENV_HOOK_WORKSPACE "@(CMAKE_INSTALL_PREFIX)"
+end
+source "$CATKIN_ENV_HOOK_WORKSPACE/share/rosbash/rosfish"
 @[end if]@


### PR DESCRIPTION
During an ongoing effort at catkin package to add native support to fish, I stumbled across an interesting bug

When ROS added support to fish, the recommended procedure was using source.bash and then manually source rosfish. In this flow, rosbash.fish env hook was never called. To add native support to fish (see https://github.com/ros/catkin/pull/1168), it is needed to ensure consistency along files (scripts ended with .fish should be compatible with fish)

In details

When we execute the instructions from [rosbash fish](http://wiki.ros.org/rosbash#fish)
```sh
bass souce ~/catkin_ws/devel/setup.bash
```

`CATKIN_SHELL` variable is set to `bash` (see [here](https://github.com/ros/catkin/blob/a31d8899b2567fe89173c2d0f49b7c66da803f91/cmake/templates/setup.bash.in#L4))
 
So, all bash (and no fish) registered environment hooks are called. At this point, registering a fish env hook have no practical effect. This lead to some undetected inconsistencies, such as `.sh` scripts registered as fish env hooks and `rosbash.fish` written with bash syntax. It is possible to deal with the former problem with an extension check (if files ends with `.sh`, use compatibility import) and this PR aims to solve the latter problem