### PR TITLE
Call realpaths for roslaunch and rosbash.

### DIFF
--- a/core/roslib/src/roslib/packages.py
+++ b/core/roslib/src/roslib/packages.py
@@ -541,4 +541,8 @@ def find_resource(pkg, resource_name, filter_fn=None, rospack=None):
     for match in matches:
         if match not in unique_matches:
             unique_matches.append(match)
+
+    # Now that we have the deduplicated matches, resolve symlinks as much as possible.
+    unique_matches = [os.path.realpath(v) for v in unique_matches]
+
     return unique_matches

--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -144,6 +144,11 @@ else
   fi
   exepath="$absname"
 fi
+# Finally, invoke realpath if possible to resolve any symlinks in the path.
+if command -v realpath &> /dev/null
+then
+  exepath=$(realpath $exepath)
+fi
 shift
 shift
 debug "Running $rosrun_prefix $exepath" "$@"


### PR DESCRIPTION
Our Nix-based ros builds create a directory that has each ros package symlinked, so instead of one directory holding all our ros packages, we have one directory holding symlinks to the ros packages. The package `move_base` would exist in `/nix/store/<hash>-sdk/merged/move_base/move_base`, but `/nix/store/<hash>-sdk/merged/move_base/` would be a symlink to `/nix/store/<hash>-move_base/`.

If symlinks are not resolved (current behaviour), the `execfn` in corefiles is the path with the symlink, so the `/nix/store/<hash>-sdk/merged/move_base/move_base` one. This means that if a developer has to investigate a core file, they need to download all of `/nix/store/<hash>-sdk` to their local system.

With the symlinks fully resolved (behaviour in this branch), the actual binary started by `rosrun` or `roslaunch` is `/nix/store/<hash>-move_base/move_base` and the developer only has to download `/nix/store/<hash>-move_base`.

fyi @mikepurvis , @jasonimercer