### PR TITLE
rosrun: Do not consider binaries from directories with CATKIN_IGNORE

### DIFF
--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -21,7 +21,7 @@ function parent_find() {
   test -e "$dir/$file" && readlink -f "$dir" && return 0
   [ '/' = "$dir" ] && return 1
 
-  parent-find "$file" "$(readlink -f "$dir/..")"
+  parent_find "$file" "$(readlink -f "$dir/..")"
 }
 
 while [ $args == 1 ]

--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -14,6 +14,17 @@ function debug() {
   return
 }
 
+function parent_find() {
+  local file="$1"
+  local dir="$2"
+
+  test -e "$dir/$file" && readlink -f "$dir" && return 0
+  [ '/' = "$dir" ] && return 1
+
+  parent-find "$file" "$(readlink -f "$dir/..")"
+}
+
+
 while [ $args == 1 ]
 do
   case "$1" in
@@ -50,21 +61,6 @@ esac
 pkg_name="$1"
 file_name="$2"
 
-function inonedir() {
-  exe=$1
-  shift
-  list_of_dirs=("$@")
-  for location in "${list_of_dirs[@]}";
-  do
-    if [[ "$exe" = "$location"* ]] ; then
-      # exe path starts with $location
-      echo "yes"
-      return
-    fi
-  done
-  echo "no"
-}
-
 if [[ -n $CMAKE_PREFIX_PATH ]]; then
   _rosrun_IFS="$IFS"
   IFS=$'\n'
@@ -88,13 +84,17 @@ if [[ ! $file_name == */* ]]; then
     _perm="/111"
   fi
   debug "Searching for $file_name with permissions $_perm"
-  exepathlist="$(find -L "${catkin_package_libexec_dirs[@]}" "$pkgdir" -name "$file_name" -type f  -perm "$_perm" ! -regex ".*$pkgdir\/build\/.*" | uniq)"
+  exepathlist="$(find -L "${catkin_package_libexec_dirs[@]}" "$pkgdir" -name "$file_name" -type f  -perm "$_perm" ! -regex ".*$pkgdir\/build\/.*" | sort -u)"
   _rosrun_IFS="$IFS"
   IFS=$'\n'
   exepathlist=($exepathlist)
   IFS="$_rosrun_IFS"
   unset _rosrun_IFS
   unset _perm
+  for index in "${!exepathlist[@]}"; do
+    parent_find CATKIN_IGNORE "$(dirname "${exepathlist[$index]}")" 1>/dev/null 2>/dev/null && debug "Excluding ${exepathlist[$index]} due to CATKIN_IGNORE" && unset -v 'exepathlist[$index]';
+  done
+  exepathlist=("${exepathlist[@]}")
   if [[ ${#exepathlist[@]} == 0 ]]; then
     echo "[rosrun] Couldn't find executable named $file_name below $pkgdir"
     nonexepathlist=($(find -H "$pkgdir" -name "$file_name"))
@@ -106,27 +106,8 @@ if [[ ! $file_name == */* ]]; then
       done
     fi
     exit 3
-  elif [[ ${#exepathlist[@]} -eq 2 ]]; then
-    # If one executable is from share and another from libexec then use one from libexec.
-    # This assumes the one from libexec is a devel-space python relay script created by catkin.
 
-    # Share dirs includes devel, install, or src space locations
-    catkin_package_share_dirs=($(catkin_find --without-underlays --share "$pkg_name" 2> /dev/null))
-    debug "Looking in catkin share dirs: $IFS$(catkin_find --without-underlays --share "$pkg_name" 2>&1)"
-
-    first_share=$(inonedir "${exepathlist[0]}" "${catkin_package_share_dirs[@]}")
-    second_share=$(inonedir "${exepathlist[1]}" "${catkin_package_share_dirs[@]}")
-
-    if [[ $first_share == "no" && $second_share == "yes" ]]; then
-      debug "Assuming ${exepathlist[0]} is a devel-space relay for ${exepathlist[1]}"
-      exepathlist=(${exepathlist[0]})
-    elif [[ $second_share == "no" && $first_share == "yes" ]]; then
-      debug "Assuming ${exepathlist[1]} is a devel-space relay for ${exepathlist[0]}"
-      exepathlist=(${exepathlist[1]})
-    fi
-  fi
-
-  if [[ ${#exepathlist[@]} -gt 1 ]]; then
+  elif [[ ${#exepathlist[@]} -gt 1 ]]; then
     echo "[rosrun] You have chosen a non-unique executable, please pick one of the following:"
     select opt in "${exepathlist[@]}"; do
       exepath="$opt"

--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -24,21 +24,6 @@ function parent_find() {
   parent-find "$file" "$(readlink -f "$dir/..")"
 }
 
-function inonedir() {
-  exe=$1
-  shift
-  list_of_dirs=("$@")
-  for location in "${list_of_dirs[@]}";
-  do
-    if [[ "$exe" = "$location"* ]] ; then
-      # exe path starts with $location
-      echo "yes"
-      return
-    fi
-  done
-  echo "no"
-}
-
 while [ $args == 1 ]
 do
   case "$1" in
@@ -74,6 +59,21 @@ esac
 
 pkg_name="$1"
 file_name="$2"
+
+function inonedir() {
+  exe=$1
+  shift
+  list_of_dirs=("$@")
+  for location in "${list_of_dirs[@]}";
+  do
+    if [[ "$exe" = "$location"* ]] ; then
+      # exe path starts with $location
+      echo "yes"
+      return
+    fi
+  done
+  echo "no"
+}
 
 if [[ -n $CMAKE_PREFIX_PATH ]]; then
   _rosrun_IFS="$IFS"

--- a/tools/rosbash/scripts/rosrun
+++ b/tools/rosbash/scripts/rosrun
@@ -24,6 +24,20 @@ function parent_find() {
   parent-find "$file" "$(readlink -f "$dir/..")"
 }
 
+function inonedir() {
+  exe=$1
+  shift
+  list_of_dirs=("$@")
+  for location in "${list_of_dirs[@]}";
+  do
+    if [[ "$exe" = "$location"* ]] ; then
+      # exe path starts with $location
+      echo "yes"
+      return
+    fi
+  done
+  echo "no"
+}
 
 while [ $args == 1 ]
 do
@@ -106,8 +120,27 @@ if [[ ! $file_name == */* ]]; then
       done
     fi
     exit 3
+  elif [[ ${#exepathlist[@]} -eq 2 ]]; then
+    # If one executable is from share and another from libexec then use one from libexec.
+    # This assumes the one from libexec is a devel-space python relay script created by catkin.
 
-  elif [[ ${#exepathlist[@]} -gt 1 ]]; then
+    # Share dirs includes devel, install, or src space locations
+    catkin_package_share_dirs=($(catkin_find --without-underlays --share "$pkg_name" 2> /dev/null))
+    debug "Looking in catkin share dirs: $IFS$(catkin_find --without-underlays --share "$pkg_name" 2>&1)"
+
+    first_share=$(inonedir "${exepathlist[0]}" "${catkin_package_share_dirs[@]}")
+    second_share=$(inonedir "${exepathlist[1]}" "${catkin_package_share_dirs[@]}")
+
+    if [[ $first_share == "no" && $second_share == "yes" ]]; then
+      debug "Assuming ${exepathlist[0]} is a devel-space relay for ${exepathlist[1]}"
+      exepathlist=(${exepathlist[0]})
+    elif [[ $second_share == "no" && $first_share == "yes" ]]; then
+      debug "Assuming ${exepathlist[1]} is a devel-space relay for ${exepathlist[0]}"
+      exepathlist=(${exepathlist[1]})
+    fi
+  fi
+
+  if [[ ${#exepathlist[@]} -gt 1 ]]; then
     echo "[rosrun] You have chosen a non-unique executable, please pick one of the following:"
     select opt in "${exepathlist[@]}"; do
       exepath="$opt"


### PR DESCRIPTION
Some IDEs (CLion) create build directories under package source folders whose name is not `build` (CLion makes `cmake-build-debug` etc.). These directories are properly initialized with catkin, so a `CATKIN_IGNORE` is put into them. However, `rosrun` still finds executables in these folders and in case of Python scripts, this results in a non-unique file to be run, which in turn results in the need of user input, which in turn makes it impossible to run these executables from launch files.

This PR fixes it and no executables under an ignored directory are considered.

However, I'm not sure if running ignored executables is not actually a valid use-case. If so, could the solution be that this pruning is only done in case there is exactly one non-ignored and one or more ignored executables?